### PR TITLE
Add arg to override the name of the text value property

### DIFF
--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -32,6 +32,7 @@ namespace XmlSchemaClassGenerator.Console
             var collectionType = typeof(Collection<>);
             Type collectionImplementationType = null;
             var codeTypeReferenceOptions = default(CodeTypeReferenceOptions);
+            string textValuePropertyName = "Value";
 
             var options = new OptionSet {
                 { "h|help", "show this message and exit", v => showHelp = v != null },
@@ -70,7 +71,8 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 { "a|pascal", "use Pascal case for class and property names (default is enabled)", v => pascal = v != null },
                 { "ct|collectionType=", "collection type to use (default is " + typeof(Collection<>).FullName + ")", v => collectionType = v == null ? typeof(Collection<>) : Type.GetType(v, true) },
                 { "cit|collectionImplementationType=", "the default collection type implementation to use (default is null)", v => collectionImplementationType = v == null ? null : Type.GetType(v, true) },
-                { "ctro|codeTypeReferenceOptions=", "the default CodeTypeReferenceOptions Flags to use (default is unset; can be: {GlobalReference, GenericTypeParameter})", v => codeTypeReferenceOptions = v == null ? default(CodeTypeReferenceOptions) : (CodeTypeReferenceOptions)Enum.Parse(typeof(CodeTypeReferenceOptions), v, false) }
+                { "ctro|codeTypeReferenceOptions=", "the default CodeTypeReferenceOptions Flags to use (default is unset; can be: {GlobalReference, GenericTypeParameter})", v => codeTypeReferenceOptions = v == null ? default(CodeTypeReferenceOptions) : (CodeTypeReferenceOptions)Enum.Parse(typeof(CodeTypeReferenceOptions), v, false) },
+                { "tvpn|textValuePropertyName=", "the name of the property that holds the text value of an element (default is Value)", v => textValuePropertyName = v }
             };
 
             var files = options.Parse(args);
@@ -110,7 +112,8 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 NamingScheme = pascal ? NamingScheme.PascalCase : NamingScheme.Direct,
                 CollectionType = collectionType,
                 CollectionImplementationType = collectionImplementationType,
-                CodeTypeReferenceOptions = codeTypeReferenceOptions
+                CodeTypeReferenceOptions = codeTypeReferenceOptions,
+                TextValuePropertyName = textValuePropertyName
             };
 
             if (pclCompatible)

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -145,6 +145,12 @@ namespace XmlSchemaClassGenerator
             set { _configuration.CodeTypeReferenceOptions = value; }
         }
 
+        public string TextValuePropertyName
+        {
+            get { return _configuration.TextValuePropertyName; }
+            set { _configuration.TextValuePropertyName = value; }
+        }
+
         /// <summary>
         /// Optional delegate that is called for each generated type member
         /// </summary>

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -116,6 +116,11 @@ namespace XmlSchemaClassGenerator
         public CodeTypeReferenceOptions CodeTypeReferenceOptions { get; set; }
 
         /// <summary>
+        /// The name of the property that will contain the text value of an XML element
+        /// </summary>
+        public string TextValuePropertyName { get; set; } = "Value";
+
+        /// <summary>
         /// Provides a fast and safe way to write to the Log
         /// </summary>
         /// <param name="messageCreator"></param>

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -275,11 +275,11 @@ namespace XmlSchemaClassGenerator
                 {
                     classDeclaration.BaseTypes.Add(BaseClass.GetReferenceFor(Namespace, false));
                 }
-                else
+                else if (!string.IsNullOrEmpty(Configuration.TextValuePropertyName))
                 {
                     var typeReference = BaseClass.GetReferenceFor(Namespace, false);
 
-                    var member = new CodeMemberField(typeReference, "Value")
+                    var member = new CodeMemberField(typeReference, Configuration.TextValuePropertyName)
                     {
                         Attributes = MemberAttributes.Public,
                     };


### PR DESCRIPTION
We have an XML scheme that already contains an element named "value" and the code generation produced a conflict with the built-in property "Value" that holds the text string for the element. Added this arg to either rename or remove the in built property.