### PR TITLE
Fix bug #54 Unhandled Exception: System.Xml.Schema.XmlSchemaException…

### DIFF
--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -188,8 +188,8 @@ namespace XmlSchemaClassGenerator
             }));
 
             foreach (var s in schemas)
-            {
-                Set.Add(s);
+            {                    
+                Set.Add(s.TargetNamespace, s.SourceUri);
             }
 
             Set.Compile();


### PR DESCRIPTION
resolved issue:
https://github.com/mganss/XmlSchemaClassGenerator/issues/54

Unhandled Exception: System.Xml.Schema.XmlSchemaException: The global element has already been declared.
at System.Xml.Schema.XmlSchemaSet.InternalValidationCallback(Object sender, ValidationEventArgs e)
at System.Xml.Schema.BaseProcessor.AddToTable(XmlSchemaObjectTable table, XmlQualifiedName qname, XmlSchemaObject item)
at System.Xml.Schema.Compiler.Prepare(XmlSchema schema, Boolean cleanup)
at System.Xml.Schema.XmlSchemaSet.Compile()
at XmlSchemaClassGenerator.Generator.Generate(IEnumerable`1 files)
at XmlSchemaClassGenerator.Console.Program.Main(String[] args)