### PR TITLE
Configurable time type

### DIFF
--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -36,6 +36,7 @@ namespace XmlSchemaClassGenerator.Console
             var generateDebuggerStepThroughAttribute = true;
             var disableComments = false;
             var doNotUseUnderscoreInPrivateMemberNames = false;
+            var timeType = false;
 
             var options = new OptionSet {
                 { "h|help", "show this message and exit", v => showHelp = v != null },
@@ -79,6 +80,7 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 { "dst|debuggerStepThrough", "generate DebuggerStepThroughAttribute (default is enabled)", v => generateDebuggerStepThroughAttribute = v != null },
                 { "dc|disableComments", "do not include comments from xsd", v => disableComments = v != null },
                 { "nu|noUnderscore", "do not generate underscore in private member name (default is false)", v => doNotUseUnderscoreInPrivateMemberNames = v != null },
+                { "tt|timeAsDatetime", "map xs:time to DateTime instead of string.", v => timeType = v != null },
             };
 
             var files = options.Parse(args);
@@ -121,7 +123,8 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 CodeTypeReferenceOptions = codeTypeReferenceOptions,
                 TextValuePropertyName = textValuePropertyName,
                 GenerateDebuggerStepThroughAttribute = generateDebuggerStepThroughAttribute,
-                DisableComments = disableComments
+                DisableComments = disableComments,
+                TimeDataType = timeType ? typeof(DateTime) : typeof(string)
             };
 
             if (pclCompatible)

--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -80,7 +80,7 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 { "dst|debuggerStepThrough", "generate DebuggerStepThroughAttribute (default is enabled)", v => generateDebuggerStepThroughAttribute = v != null },
                 { "dc|disableComments", "do not include comments from xsd", v => disableComments = v != null },
                 { "nu|noUnderscore", "do not generate underscore in private member name (default is false)", v => doNotUseUnderscoreInPrivateMemberNames = v != null },
-                { "tt|timeAsDatetime", "map xs:time to DateTime instead of string.", v => timeType = v != null },
+                { "tt|timeAsDateTime", "map xs:time to DateTime instead of string", v => timeType = v != null },
             };
 
             var files = options.Parse(args);

--- a/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
+++ b/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
@@ -1,5 +1,4 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
   <PropertyGroup>
     <TargetFrameworks>net452</TargetFrameworks>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
@@ -14,12 +13,10 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\XmlSampleGenerator\XmlSampleGenerator.csproj" />
     <ProjectReference Include="..\XmlSchemaClassGenerator\XmlSchemaClassGenerator.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.6.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
@@ -28,11 +25,9 @@
     <PackageReference Include="xunit.extensibility.core" Version="2.3.1" />
     <PackageReference Include="xunit.extensibility.execution" Version="2.3.1" />
   </ItemGroup>
-
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-
   <ItemGroup>
     <None Update="xml\apartmentBuy_max.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -271,6 +266,8 @@
     <None Update="xsd\wadl\xml.xsd">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="xsd\time\time.xsd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
-
 </Project>

--- a/XmlSchemaClassGenerator.Tests/xsd/time/time.xsd
+++ b/XmlSchemaClassGenerator.Tests/xsd/time/time.xsd
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<xsd:schema xmlns="http://www.w3.org/2001/XMLSchema"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+            targetNamespace="http://hic.gov.au/hiconline/medicare/version-4">
+    
+    <xsd:complexType name="Service">
+        <xsd:attribute name="dateOfService" type="xsd:dateTime" />
+        <xsd:attribute name="timeOfService" type="xsd:time" />
+    </xsd:complexType>
+</xsd:schema>

--- a/XmlSchemaClassGenerator/CodeUtilities.cs
+++ b/XmlSchemaClassGenerator/CodeUtilities.cs
@@ -92,8 +92,19 @@ namespace XmlSchemaClassGenerator
                 case XmlTypeCode.GMonthDay:
                 case XmlTypeCode.GYear:
                 case XmlTypeCode.GYearMonth:
-                case XmlTypeCode.Time:
                     result = variety == XmlSchemaDatatypeVariety.List ? typeof(string[]) : typeof(string);
+                    break;
+                case XmlTypeCode.Time:
+                    if (configuration.TimeDataType == null || configuration.TimeDataType == typeof(string))
+                    {
+                        // default to string
+                        result = typeof(string);
+                    }
+                    else
+                    {
+                        // otherwise, use the specified type
+                        result = configuration.TimeDataType;
+                    }
                     break;
                 case XmlTypeCode.Integer:
                 case XmlTypeCode.NegativeInteger:

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -178,6 +178,12 @@ namespace XmlSchemaClassGenerator
             get { return _configuration.DoNotUseUnderscoreInPrivateMemberNames; }
             set { _configuration.DoNotUseUnderscoreInPrivateMemberNames = value; }
         }
+        
+        public Type TimeDataType
+        {
+            get { return _configuration.TimeDataType; }
+            set { _configuration.TimeDataType = value; }
+        }
 
         private readonly XmlSchemaSet Set = new XmlSchemaSet();
         private Dictionary<XmlQualifiedName, XmlSchemaAttributeGroup> AttributeGroups;

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -159,6 +159,10 @@ namespace XmlSchemaClassGenerator
 
         public bool DisableComments { get; set; }
         public bool DoNotUseUnderscoreInPrivateMemberNames { get; set; }
-
+        
+        /// <summary>
+        /// Default data type for time fields. Defaults to string if not set.
+        /// </summary>
+        public Type TimeDataType { get; set; }
     }
 }


### PR DESCRIPTION
This PR resolves #37 

The standard XmlSerialiser **only** supports serializing xsd:time as a DateTime, so rather than making the type configurable, I have simply made a switch to enable/disabled use of DateTime for xsd:time.

It is disabled by default, to maintain compatibility with existing behavior.