### PR TITLE
Stop default value of false from erroring

### DIFF
--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -192,6 +192,7 @@ namespace XmlSchemaClassGenerator
         }
     }
 
+    [DebuggerDisplay("[ClassModel] Name = {Name}")]
     public class ClassModel : TypeModel
     {
         public bool IsAbstract { get; set; }
@@ -399,6 +400,11 @@ namespace XmlSchemaClassGenerator
 
         public override CodeExpression GetDefaultValueFor(string defaultString)
         {
+            if (defaultString == "false")
+            {
+                return null;
+            }
+
             if (BaseClass is SimpleModel)
             {
                 string reference, val;
@@ -423,6 +429,7 @@ namespace XmlSchemaClassGenerator
         }
     }
 
+    [DebuggerDisplay("Name = {Name}")]
     public class PropertyModel
     {
         public TypeModel OwningType { get; set; }


### PR DESCRIPTION
When running this tool against the OVAL Scap 5.11 XSD files (Found at https://oval.mitre.org/language/version5.11/ovaldefinition/complete/oval-definitions-schema-complete.zip ) I was getting the following error:

> Unhandled Exception: System.NotSupportedException: Getting default value for false not supported.
>    at XmlSchemaClassGenerator.TypeModel.GetDefaultValueFor(String defaultString)
>    at XmlSchemaClassGenerator.ClassModel.GetDefaultValueFor(String defaultString)
>    at XmlSchemaClassGenerator.PropertyModel.AddMembersTo(CodeTypeDeclaration typeDeclaration, Boolean withDataBinding)
>    at XmlSchemaClassGenerator.ClassModel.Generate()
>    at XmlSchemaClassGenerator.NamespaceModel.Generate(String namespaceName, IEnumerable`1 parts)
>    at XmlSchemaClassGenerator.ModelBuilder.<>c.<GenerateCode>b__22_2(NamespaceHierarchyItem nhi)
>    at System.Linq.Enumerable.WhereSelectEnumerableIterator`2.MoveNext()
>    at XmlSchemaClassGenerator.Generator.Generate(XmlSchemaSet set)
>    at XmlSchemaClassGenerator.Generator.Generate(IEnumerable`1 files)
>    at XmlSchemaClassGenerator.Console.Program.Main(String[] args)

The first error appears to be linked to windows-definitions-schema.xsd, line 4146:
`<xsd:element name="image_file_relocs_stripped" type="oval-def:EntityStateBoolType" default="false" minOccurs="0" maxOccurs="1">`

I'm not sure what I'm doing is the right thing - any advice is welcome.