### PR TITLE
Properly calculate IsNullable on elements in a choice inside a sequence

### DIFF
--- a/XmlSchemaClassGenerator/Particle.cs
+++ b/XmlSchemaClassGenerator/Particle.cs
@@ -9,14 +9,16 @@ namespace XmlSchemaClassGenerator
 {
     public class Particle
     {
-        public Particle(XmlSchemaParticle particle)
+        public Particle(XmlSchemaParticle particle, XmlSchemaObject parent)
         {
             XmlParticle = particle;
+            XmlParent = parent;
             MinOccurs = particle.MinOccurs;
             MaxOccurs = particle.MaxOccurs;
         }
 
         public XmlSchemaParticle XmlParticle { get; set; }
+        public XmlSchemaObject XmlParent { get; }
         public decimal MaxOccurs { get; set; }
         public decimal MinOccurs { get; set; }
     }

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -456,6 +456,8 @@ namespace XmlSchemaClassGenerator
         public bool IsAny { get; set; }
         public int? Order { get; set; }
         public bool IsKey { get; set; }
+        public XmlSchemaParticle XmlParticle { get; set; }
+        public XmlSchemaObject XmlParent { get; set; }
         public GeneratorConfiguration Configuration { get; private set; }
 
         public PropertyModel(GeneratorConfiguration configuration)


### PR DESCRIPTION
The old logic for IsNullable took account of choices (marking each
element inside a choice as nullable), but only if the choice appeared as
the root of a complexType. If the choice appeared inside a sequence inside
a complexType, then ModelBuilder.GetElements would forget the fact that
a choice was ever involved.

This XSD worked as expected, with Opt1 and Opt2 being marked as
nullable:

    <?xml version="1.0" encoding="utf-8" ?>
    <schema elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema">
      <element name="Root">
        <complexType>
          <choice>
            <element name="Opt1" type="string"/>
            <element name="Opt2" type="string"/>
          </choice>
        </complexType>
      </element>
    </schema>

This XSD did not work as expected, with Opt1 and Opt2 not being marked
as nullable. This is because nullability was determined by looking at
the complexType containing "Foo":

    <?xml version="1.0" encoding="utf-8" ?>
    <schema elementFormDefault="qualified" xmlns="http://www.w3.org/2001/XMLSchema">
      <element name="Root">
        <complexType>
          <sequence>
            <element name="Foo" type="string"/>
            <choice>
              <element name="Opt1" type="string"/>
              <element name="Opt2" type="string"/>
            </choice>
          </sequence>
        </complexType>
      </element>
    </schema>

Also expose the XmlParticle and XmlParent on the PropertyModel. This
gives the MemberVisitor a bit more information, for example it can now
output a custom DataAnnotations attribute which verifies that exactly
one member of a choice is populated.