### PR TITLE
EditorBrowsableAttribute values should respect CodeTypeReferenceOptio…

### DIFF
--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -850,8 +850,8 @@ namespace XmlSchemaClassGenerator
                     typeDeclaration.Members.Add(nullableMember);
 
                     var editorBrowsableAttribute = new CodeAttributeDeclaration(new CodeTypeReference(typeof(EditorBrowsableAttribute), Configuration.CodeTypeReferenceOptions));
-                    editorBrowsableAttribute.Arguments.Add(new CodeAttributeArgument(new CodeFieldReferenceExpression(new CodeTypeReferenceExpression(typeof(EditorBrowsableState)), "Never")));
-                    specifiedMember.CustomAttributes.Add(editorBrowsableAttribute);
+                    editorBrowsableAttribute.Arguments.Add(new CodeAttributeArgument(new CodeFieldReferenceExpression(new CodeTypeReferenceExpression(new CodeTypeReference(typeof(EditorBrowsableState), Configuration.CodeTypeReferenceOptions)), "Never")));
+					specifiedMember.CustomAttributes.Add(editorBrowsableAttribute);
                     member.CustomAttributes.Add(editorBrowsableAttribute);
                     if (Configuration.EntityFramework) { member.CustomAttributes.Add(notMappedAttribute); }
                 }


### PR DESCRIPTION
…ns to mitigate/avoid collisions.

Bumped into a schema that generates field `System` -> attribute value of `System.ComponentModel.EditorBrowsableState.Never` collides with it.