### PR TITLE
If member names collide (e.g. attributes with the same names but from…

### DIFF
--- a/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
+++ b/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
@@ -128,6 +128,12 @@
     <None Update="xml\office_min.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="xml\sameattributenames.xsd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="xml\sameattributenames_import.xsd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="xml\seniorCare_max.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -378,6 +378,16 @@ namespace XmlSchemaClassGenerator.Tests
 	    }
 
 
+	    [Theory]
+		[InlineData(@"xml/sameattributenames.xsd", @"xml/sameattributenames_import.xsd")]
+	    public void CollidingAttributeAndPropertyNamesCanBeResolved(params string[] files)
+	    {
+			// Compilation would previously throw due to duplicate type name within type
+		    var assembly = Compiler.GenerateFiles("AttributesWithSameName", files);		    
+
+			Assert.NotNull(assembly);
+	    }
+
 		[Fact]
         public void ComplexTypeWithAttributeGroupExtension()
         {

--- a/XmlSchemaClassGenerator.Tests/xml/sameattributenames.xsd
+++ b/XmlSchemaClassGenerator.Tests/xml/sameattributenames.xsd
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:a="http://none.local/a" xmlns:b="http://none.local/b" elementFormDefault="qualified" targetNamespace="http://none.local/a">
+   <import namespace="http://none.local/b" schemaLocation="sameattributenames_import.xsd" />
+   <element name="document" type="a:elem" />
+   <element name="document2" type="a:elem2" />
+   <complexType name="elem">
+      <sequence>
+         <element name="Type" type="a:elem2" />
+      </sequence>
+      <attribute ref="b:type" />
+      <attribute name="type" type="string" />
+   </complexType>
+   <complexType name="elem2">
+      <attribute name="type" type="string" />
+   </complexType>
+</schema>

--- a/XmlSchemaClassGenerator.Tests/xml/sameattributenames_import.xsd
+++ b/XmlSchemaClassGenerator.Tests/xml/sameattributenames_import.xsd
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" targetNamespace="http://none.local/b" xmlns:b="http://none.local/b">
+ <xs:attribute name="type" type="b:typeType"/>
+ <xs:simpleType name="typeType">
+  <xs:restriction base="xs:token">
+   <xs:enumeration value="a"/>
+   <xs:enumeration value="b"/>
+  </xs:restriction>
+ </xs:simpleType>
+</xs:schema>

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -383,10 +383,24 @@ namespace XmlSchemaClassGenerator
                 keyProperty.IsKey = true;
             }
 
-            foreach (var property in Properties)
-                property.AddMembersTo(classDeclaration, Configuration.EnableDataBinding);
+	        foreach (var property in Properties.GroupBy(x => x.Name))
+	        {
+		        property.First().AddMembersTo(classDeclaration, Configuration.EnableDataBinding);
 
-            if (IsMixed && (BaseClass == null || (BaseClass is ClassModel && !AllBaseClasses.Any(b => b.IsMixed))))
+				if (property.Count() > 1)
+		        {			        
+					var propertyIndex = 1;
+			        foreach (var n in property.Skip(1))
+			        {
+				        n.Name += $"_{propertyIndex}";
+				        propertyIndex++;
+				        n.AddMembersTo(classDeclaration, Configuration.EnableDataBinding);
+					}
+				}
+		        
+	        }
+
+	        if (IsMixed && (BaseClass == null || (BaseClass is ClassModel && !AllBaseClasses.Any(b => b.IsMixed))))
             {
                 var text = new CodeMemberField(typeof(string), "Text");
                 // hack to generate automatic property

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -385,19 +385,16 @@ namespace XmlSchemaClassGenerator
 
 	        foreach (var property in Properties.GroupBy(x => x.Name))
 	        {
-		        property.First().AddMembersTo(classDeclaration, Configuration.EnableDataBinding);
-
-				if (property.Count() > 1)
-		        {			        
-					var propertyIndex = 1;
-			        foreach (var n in property.Skip(1))
+		        var propertyIndex = 0;
+		        foreach (var p in property)
+		        {
+			        if (propertyIndex > 0)
 			        {
-				        n.Name += $"_{propertyIndex}";
-				        propertyIndex++;
-				        n.AddMembersTo(classDeclaration, Configuration.EnableDataBinding);
+				        p.Name += $"_{propertyIndex}";
 					}
-				}
-		        
+			        p.AddMembersTo(classDeclaration, Configuration.EnableDataBinding);
+					propertyIndex++;
+		        }
 	        }
 
 	        if (IsMixed && (BaseClass == null || (BaseClass is ClassModel && !AllBaseClasses.Any(b => b.IsMixed))))


### PR DESCRIPTION
… different namespaces), override names to non-colliding.

Would this be the way to go? If so and deemed needed, I can put it behind a flag (or interface with callbacks). Need something similar for a schema that has attributes with the same name, but different namespaces and also elements with with the same names as attributes -> .NET member names collide.

The added test never hits NamingProvider, but even then, keeping track of collisions in NamingProvider seems unconvenient (if even possible?).
