### PR TITLE
For mixed complexTypes, the XmlTextAttribute member should not collid…

### DIFF
--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -377,8 +377,32 @@ namespace XmlSchemaClassGenerator.Tests
 			    generatedType.First());
 	    }
 
+		[Fact]
+		public void MixedTypeMustNotCollideWithExistingMembers()
+		{
+			const string xsd = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"" targetNamespace=""http://local.none"" xmlns:l=""http://local.none"">  
+	<xs:element name=""document"" type=""l:elem"">			
+	</xs:element>
+	<xs:complexType name=""elem"" mixed=""true"">
+		<xs:attribute name=""Text"" type=""xs:string""/>
+	</xs:complexType>	
+</xs:schema>";
 
-	    [Theory]
+			var generatedType = ConvertXml(nameof(MixedTypeMustNotCollideWithExistingMembers), xsd, new Generator
+			{
+				NamespaceProvider = new NamespaceProvider
+				{
+					GenerateNamespace = key => "Test"
+				}
+			});
+
+			Assert.Contains(
+				@"public string[] Text_1 { get; set; }",
+				generatedType.First());
+		}
+
+		[Theory]
 		[InlineData(@"xml/sameattributenames.xsd", @"xml/sameattributenames_import.xsd")]
 	    public void CollidingAttributeAndPropertyNamesCanBeResolved(params string[] files)
 	    {

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -402,6 +402,30 @@ namespace XmlSchemaClassGenerator.Tests
 				generatedType.First());
 		}
 
+	    [Fact]
+	    public void MixedTypeMustNotCollideWithContainingTypeName()
+	    {
+		    const string xsd = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"" targetNamespace=""http://local.none"" xmlns:l=""http://local.none"">  
+	<xs:element name=""document"" type=""l:Text"">			
+	</xs:element>
+	<xs:complexType name=""Text"" mixed=""true"">		
+	</xs:complexType>	
+</xs:schema>";
+
+		    var generatedType = ConvertXml(nameof(MixedTypeMustNotCollideWithExistingMembers), xsd, new Generator
+		    {
+			    NamespaceProvider = new NamespaceProvider
+			    {
+				    GenerateNamespace = key => "Test"
+			    }
+		    });
+
+		    Assert.Contains(
+			    @"public string[] Text_1 { get; set; }",
+			    generatedType.First());
+	    }
+
 		[Theory]
 		[InlineData(@"xml/sameattributenames.xsd", @"xml/sameattributenames_import.xsd")]
 	    public void CollidingAttributeAndPropertyNamesCanBeResolved(params string[] files)

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -53,7 +53,8 @@ namespace XmlSchemaClassGenerator
 
             foreach (var rootElement in set.GlobalElements.Values.Cast<XmlSchemaElement>())
             {
-                var source = new Uri(rootElement.GetSchema().SourceUri);
+	            var rootSchema = rootElement.GetSchema();
+				var source = !string.IsNullOrEmpty(rootSchema.SourceUri) ? new Uri(rootElement.GetSchema().SourceUri) : default(Uri);
                 var qualifiedName = rootElement.ElementSchemaType.QualifiedName;
                 if (qualifiedName.IsEmpty) { qualifiedName = rootElement.QualifiedName; }
                 var type = CreateTypeModel(source, rootElement.ElementSchemaType, qualifiedName);

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -402,7 +402,7 @@ namespace XmlSchemaClassGenerator
 		        var propName = "Text";		        
 
 				// To not collide with any existing members
-				for (var propertyIndex = 1; Properties.Any(x => x.Name.Equals(propName, StringComparison.Ordinal)); propertyIndex++)
+				for (var propertyIndex = 1; Properties.Any(x => x.Name.Equals(propName, StringComparison.Ordinal)) || propName.Equals(classDeclaration.Name, StringComparison.Ordinal); propertyIndex++)
 		        {					
 			        propName = $"Text_{propertyIndex}";			        
 				} 

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -398,8 +398,15 @@ namespace XmlSchemaClassGenerator
 	        }
 
 	        if (IsMixed && (BaseClass == null || (BaseClass is ClassModel && !AllBaseClasses.Any(b => b.IsMixed))))
-            {
-                var text = new CodeMemberField(typeof(string), "Text");
+	        {
+		        var propName = "Text";		        
+
+				// To not collide with any existing members
+				for (var propertyIndex = 1; Properties.Any(x => x.Name.Equals(propName, StringComparison.Ordinal)); propertyIndex++)
+		        {					
+			        propName = $"Text_{propertyIndex}";			        
+				} 
+                var text = new CodeMemberField(typeof(string[]), propName);
                 // hack to generate automatic property
                 text.Name += " { get; set; }";
                 text.Attributes = MemberAttributes.Public;


### PR DESCRIPTION
…e with existing members.

XmlTextAttribute member `string` -> `string[]` (so no data loss in serializing mixed elements).

Bumped into this while generating types for schemas with mixed complex types with elements named `Text`.