### PR TITLE
More fine-grained mapping for xs:integer and derived types

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Features
 from schema restrictions
 * Use [`Collection<T>`](http://msdn.microsoft.com/en-us/library/ms132397.aspx) properties 
 (initialized in constructor and with private setter)
-* Use either int, long, decimal, or string for xs:integer and derived types
+* Map xs:integer and derived types to the closest possible .NET type, if not possible - fall back to string. Can be overriden by explicitly defined type (int, long, or decimal)
 * Automatic properties
 * Pascal case for classes and properties
 * Generate nullable adapter properties for optional elements and attributes without default values (see [below](#nullables))
@@ -254,6 +254,26 @@ Collection types
 
 Values for the `--collectionType` and `--collectionImplementationType` options have to be given in the format accepted by
 the [`Type.GetType()`](https://docs.microsoft.com/en-us/dotnet/api/system.type.gettype) method. For the `System.Collections.Generic.List<T>` class this means ``System.Collections.Generic.List`1``.
+
+Integer and derived types
+---------------------
+Not all numeric types defined by XML Schema can be safely and accurately mapped to .NET numeric data types, however, it's possible to approximate the mapping based on the integer bounds and restrictions such as `totalDigits`.  
+If an explicit integer type mapping is specified via `--integer=TYPE`, that type will be used, otherwise an approximation will be made based on the following table:
+
+| XML Schema type | totalDigits | C# type|
+|-----------------|-------------|---------|
+| xs:positiveInteger, xs:nonNegativeInteger| <3 | byte |
+| xs:positiveInteger, xs:nonNegativeInteger| <5 | ushort |
+| xs:positiveInteger, xs:nonNegativeInteger| <10 | uint |
+| xs:positiveInteger, xs:nonNegativeInteger| <20 | ulong |
+| xs:positiveInteger, xs:nonNegativeInteger| <30 | decimal |
+| xs:positiveInteger, xs:nonNegativeInteger| >=30 | string |
+| xs:integer, xs:nonPositiveInteger, xs:negativeInteger| <3 | sbyte |
+| xs:integer, xs:nonPositiveInteger, xs:negativeInteger| <5 | short |
+| xs:integer, xs:nonPositiveInteger, xs:negativeInteger| <10 | int |
+| xs:integer, xs:nonPositiveInteger, xs:negativeInteger| <19 | long |
+| xs:integer, xs:nonPositiveInteger, xs:negativeInteger| <29 | decimal |
+| xs:integer, xs:nonPositiveInteger, xs:negativeInteger| >=29 | string |
 
 Contributing
 ------------

--- a/XmlSchemaClassGenerator.sln
+++ b/XmlSchemaClassGenerator.sln
@@ -11,7 +11,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XmlSampleGenerator", "XmlSa
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "XmlSchemaClassGenerator.Console", "XmlSchemaClassGenerator.Console\XmlSchemaClassGenerator.Console.csproj", "{F0000FE1-DE27-4BF9-A179-FC9643A57EEE}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "xscgen", "xscgen\xscgen.csproj", "{C5C1FF7F-31AD-4D4F-81F3-C9F54516D9D0}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "xscgen", "xscgen\xscgen.csproj", "{C5C1FF7F-31AD-4D4F-81F3-C9F54516D9D0}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{6ED7BE60-B3EC-4CBA-8732-09DA45AC14BF}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -377,7 +377,7 @@ namespace XmlSchemaClassGenerator
                 Namespace = namespaceModel,
                 XmlSchemaName = qualifiedName,
                 XmlSchemaType = simpleType,
-                ValueType = simpleType.Datatype.GetEffectiveType(_configuration),
+                ValueType = simpleType.Datatype.GetEffectiveType(_configuration, restrictions),
             };
 
             simpleModel.Documentation.AddRange(docs);

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -7,7 +7,6 @@ using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics;
 using System.Linq;
-using System.Reflection;
 using System.Text.RegularExpressions;
 using System.Xml;
 using System.Xml.Schema;
@@ -1190,7 +1189,7 @@ namespace XmlSchemaClassGenerator
                 // http://msdn.microsoft.com/en-us/library/system.xml.serialization.xmlelementattribute.datatype(v=vs.110).aspx
                 // XmlSerializer is inconsistent: maps xs:decimal to decimal but xs:integer to string,
                 // even though xs:integer is a restriction of xs:decimal
-                type = XmlSchemaType.GetEffectiveType(Configuration);
+                type = XmlSchemaType.GetEffectiveType(Configuration, Restrictions);
                 UseDataTypeAttribute = XmlSchemaType.IsDataTypeAttributeAllowed(Configuration) ?? UseDataTypeAttribute;
             }
 


### PR DESCRIPTION
Implements one part of #89.

Sorry about the whitespace changes, my IDE is set up to clean up various things automatically.