### PR TITLE
Control over XmlSchemaSet checking for UPA violations

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ Options:
                                groups (default is enabled)
   -a, --pascal               use Pascal case for class and property names (
                                default is enabled)
+  -u, --enableUpaCheck       should XmlSchemaSet check for Unique Particle 
+                               Attribution (UPA) (default is enabled)
       --ct, --collectionType=VALUE
                              collection type to use (default is System.
                                Collections.ObjectModel.Collection`1)

--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -38,6 +38,7 @@ namespace XmlSchemaClassGenerator.Console
             var disableComments = false;
             var doNotUseUnderscoreInPrivateMemberNames = false;
             var generateDescriptionAttribute = true;
+            var enableUpaCheck = true;
 
             var options = new OptionSet {
                 { "h|help", "show this message and exit", v => showHelp = v != null },
@@ -74,6 +75,7 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 { "f|ef", "generate Entity Framework Code First compatible classes", v => entityFramework = v != null },
                 { "t|interface", "generate interfaces for groups and attribute groups (default is enabled)", v => interfaces = v != null },
                 { "a|pascal", "use Pascal case for class and property names (default is enabled)", v => pascal = v != null },
+                { "u|enableUpaCheck", "should XmlSchemaSet check for Unique Particle Attribution (UPA) (default is enabled)", v => enableUpaCheck = v != null },
                 { "ct|collectionType=", "collection type to use (default is " + typeof(Collection<>).FullName + ")", v => collectionType = v == null ? typeof(Collection<>) : Type.GetType(v, true) },
                 { "cit|collectionImplementationType=", "the default collection type implementation to use (default is null)", v => collectionImplementationType = v == null ? null : Type.GetType(v, true) },
                 { "ctro|codeTypeReferenceOptions=", "the default CodeTypeReferenceOptions Flags to use (default is unset; can be: {GlobalReference, GenericTypeParameter})", v => codeTypeReferenceOptions = v == null ? default(CodeTypeReferenceOptions) : (CodeTypeReferenceOptions)Enum.Parse(typeof(CodeTypeReferenceOptions), v, false) },
@@ -126,7 +128,8 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 GenerateDebuggerStepThroughAttribute = generateDebuggerStepThroughAttribute,
                 DisableComments = disableComments,
                 GenerateDescriptionAttribute = generateDescriptionAttribute,
-                DoNotUseUnderscoreInPrivateMemberNames = doNotUseUnderscoreInPrivateMemberNames
+                DoNotUseUnderscoreInPrivateMemberNames = doNotUseUnderscoreInPrivateMemberNames,
+                EnableUpaCheck = enableUpaCheck
             };
 
             if (pclCompatible)

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -193,6 +193,12 @@ namespace XmlSchemaClassGenerator
             set { _configuration.DoNotUseUnderscoreInPrivateMemberNames = value; }
         }
 
+        public bool EnableUpaCheck
+        {
+            get { return _configuration.EnableUpaCheck; }
+            set { _configuration.EnableUpaCheck = value; }
+        }
+
         public void Generate(IEnumerable<string> files)
         {
             var set = new XmlSchemaSet();
@@ -216,6 +222,7 @@ namespace XmlSchemaClassGenerator
 
         public void Generate(XmlSchemaSet set)
         {
+            set.CompilationSettings.EnableUpaCheck = EnableUpaCheck;
             set.Compile();
 
             var m = new ModelBuilder(_configuration, set);

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -35,6 +35,7 @@ namespace XmlSchemaClassGenerator
             MemberVisitor = (member, model) => { };
             NamingProvider = new NamingProvider(NamingScheme);
             Version = VersionProvider.CreateFromAssembly();
+            EnableUpaCheck = true;
         }
 
         /// <summary>
@@ -171,5 +172,10 @@ namespace XmlSchemaClassGenerator
 
         public bool DisableComments { get; set; }
         public bool DoNotUseUnderscoreInPrivateMemberNames { get; set; }
+        
+        /// <summary>
+        /// Check for Unique Particle Attribution (UPA) violations
+        /// </summary>
+        public bool EnableUpaCheck { get; set; }
     }
 }


### PR DESCRIPTION
Added a new parameter u|enableUpaCheck to gain access to `XmlSchemaSet.CompilationSettings.EnableUpaCheck`. Default is set to true as per https://docs.microsoft.com/en-us/dotnet/api/system.xml.schema.xmlschemacompilationsettings.enableupacheck , use -u- to disable the check and avoid the following exception with `xs:any` elements:

System.Xml.Schema.XmlSchemaException: Wildcard '##other' allows element 'a_namespace_different_than_target:element', and causes the content model to become ambiguous. A content model must be formed such that during validation of an element information item sequence, the particle contained directly, indirectly or implicitly therein with which to attempt to validate each item in the sequence in turn can be uniquely determined without examining the content or attributes of that item, and without any information about the items in the remainder of the sequence.