### PR TITLE
added new project-level cli tool to support DotNetCliToolReference

### DIFF
--- a/XmlSchemaClassGenerator/XmlSchemaClassGenerator.csproj
+++ b/XmlSchemaClassGenerator/XmlSchemaClassGenerator.csproj
@@ -6,7 +6,7 @@
     <AssemblyTitle>XmlSchemaClassGenerator</AssemblyTitle>
     <VersionPrefix>1.0.0-VERSION</VersionPrefix>
     <Authors>Michael Ganss</Authors>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <AssemblyName>XmlSchemaClassGenerator</AssemblyName>
     <PackageId>XmlSchemaClassGenerator-beta</PackageId>
     <PackageTags>xsd</PackageTags>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ build_script:
   - dotnet pack --include-symbols --include-source -c Release XmlSchemaClassGenerator
   - dotnet pack --include-symbols --include-source -c Release XmlSchemaClassGenerator.Console
   - dotnet pack --include-symbols --include-source -c Release xscgen
-  - dotnet pack --include-symbols --include-source -c Release xscgen-csproj
+  - dotnet pack --include-symbols --include-source -c Release dotnet-xscgen
   - 7z a -mx=9 XmlSchemaClassGenerator.%APPVEYOR_BUILD_VERSION%.zip ".\XmlSchemaClassGenerator.Console\bin\Release\net45\publish\*"
 test_script:
   - ps: |
@@ -40,7 +40,7 @@ artifacts:
   - path: 'XmlSchemaClassGenerator\**\*.nupkg'
   - path: 'XmlSchemaClassGenerator.Console\**\*.nupkg'
   - path: 'xscgen\**\*.nupkg'
-  - path: 'xscgen-csproj\**\*.nupkg'
+  - path: 'dotnet-xscgen\**\*.nupkg'
   - path: XmlSchemaClassGenerator.%APPVEYOR_BUILD_VERSION%.zip
 on_success:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,7 @@ build_script:
   - ps: (Get-Content XmlSchemaClassGenerator\XmlSchemaClassGenerator.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content XmlSchemaClassGenerator\XmlSchemaClassGenerator.csproj
   - ps: (Get-Content XmlSchemaClassGenerator.Console\XmlSchemaClassGenerator.Console.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content XmlSchemaClassGenerator.Console\XmlSchemaClassGenerator.Console.csproj
   - ps: (Get-Content xscgen\xscgen.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content xscgen\xscgen.csproj
+  - ps: (Get-Content xscgen\dotnet-xscgen.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content dotnet-xscgen\dotnet-xscgen.csproj
   - dotnet --info
   - dotnet restore
   - dotnet build -c Release
@@ -19,6 +20,7 @@ build_script:
   - dotnet pack --include-symbols --include-source -c Release XmlSchemaClassGenerator
   - dotnet pack --include-symbols --include-source -c Release XmlSchemaClassGenerator.Console
   - dotnet pack --include-symbols --include-source -c Release xscgen
+  - dotnet pack --include-symbols --include-source -c Release xscgen-csproj
   - 7z a -mx=9 XmlSchemaClassGenerator.%APPVEYOR_BUILD_VERSION%.zip ".\XmlSchemaClassGenerator.Console\bin\Release\net45\publish\*"
 test_script:
   - ps: |
@@ -38,6 +40,7 @@ artifacts:
   - path: 'XmlSchemaClassGenerator\**\*.nupkg'
   - path: 'XmlSchemaClassGenerator.Console\**\*.nupkg'
   - path: 'xscgen\**\*.nupkg'
+  - path: 'xscgen-csproj\**\*.nupkg'
   - path: XmlSchemaClassGenerator.%APPVEYOR_BUILD_VERSION%.zip
 on_success:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ build_script:
   - ps: (Get-Content XmlSchemaClassGenerator\XmlSchemaClassGenerator.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content XmlSchemaClassGenerator\XmlSchemaClassGenerator.csproj
   - ps: (Get-Content XmlSchemaClassGenerator.Console\XmlSchemaClassGenerator.Console.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content XmlSchemaClassGenerator.Console\XmlSchemaClassGenerator.Console.csproj
   - ps: (Get-Content xscgen\xscgen.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content xscgen\xscgen.csproj
-  - ps: (Get-Content xscgen-csproj\dotnet-xscgen.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content dotnet-xscgen\dotnet-xscgen.csproj
+  - ps: (Get-Content dotnet-xscgen\dotnet-xscgen.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content dotnet-xscgen\dotnet-xscgen.csproj
   - dotnet --info
   - dotnet restore
   - dotnet build -c Release

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ build_script:
   - ps: (Get-Content XmlSchemaClassGenerator\XmlSchemaClassGenerator.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content XmlSchemaClassGenerator\XmlSchemaClassGenerator.csproj
   - ps: (Get-Content XmlSchemaClassGenerator.Console\XmlSchemaClassGenerator.Console.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content XmlSchemaClassGenerator.Console\XmlSchemaClassGenerator.Console.csproj
   - ps: (Get-Content xscgen\xscgen.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content xscgen\xscgen.csproj
-  - ps: (Get-Content dotnet-xscgen\dotnet-xscgen.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content dotnet-xscgen\dotnet-xscgen.csproj
+  - ps: (Get-Content xscgen-proj\xscgen-proj.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content xscgen-proj\xscgen-proj.csproj
   - dotnet --info
   - dotnet restore
   - dotnet build -c Release
@@ -20,7 +20,7 @@ build_script:
   - dotnet pack --include-symbols --include-source -c Release XmlSchemaClassGenerator
   - dotnet pack --include-symbols --include-source -c Release XmlSchemaClassGenerator.Console
   - dotnet pack --include-symbols --include-source -c Release xscgen
-  - dotnet pack --include-symbols --include-source -c Release dotnet-xscgen
+  - dotnet pack --include-symbols --include-source -c Release xscgen-proj
   - 7z a -mx=9 XmlSchemaClassGenerator.%APPVEYOR_BUILD_VERSION%.zip ".\XmlSchemaClassGenerator.Console\bin\Release\net45\publish\*"
 test_script:
   - ps: |
@@ -40,7 +40,7 @@ artifacts:
   - path: 'XmlSchemaClassGenerator\**\*.nupkg'
   - path: 'XmlSchemaClassGenerator.Console\**\*.nupkg'
   - path: 'xscgen\**\*.nupkg'
-  - path: 'dotnet-xscgen\**\*.nupkg'
+  - path: 'xscgen-proj\**\*.nupkg'
   - path: XmlSchemaClassGenerator.%APPVEYOR_BUILD_VERSION%.zip
 on_success:
   - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ build_script:
   - ps: (Get-Content XmlSchemaClassGenerator\XmlSchemaClassGenerator.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content XmlSchemaClassGenerator\XmlSchemaClassGenerator.csproj
   - ps: (Get-Content XmlSchemaClassGenerator.Console\XmlSchemaClassGenerator.Console.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content XmlSchemaClassGenerator.Console\XmlSchemaClassGenerator.Console.csproj
   - ps: (Get-Content xscgen\xscgen.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content xscgen\xscgen.csproj
-  - ps: (Get-Content xscgen\dotnet-xscgen.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content dotnet-xscgen\dotnet-xscgen.csproj
+  - ps: (Get-Content xscgen-csproj\dotnet-xscgen.csproj).Replace("1.0.0-VERSION", $env:APPVEYOR_BUILD_VERSION) | Set-Content dotnet-xscgen\dotnet-xscgen.csproj
   - dotnet --info
   - dotnet restore
   - dotnet build -c Release

--- a/dotnet-xscgen/dotnet-xscgen.csproj
+++ b/dotnet-xscgen/dotnet-xscgen.csproj
@@ -1,0 +1,34 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <Description>A .NET Core CLI tool to generate XmlSerializer compatible C# classes from XML Schema files.</Description>
+    <Copyright>Copyright 2013-2018 Michael Ganss</Copyright>
+    <AssemblyTitle>xscgen</AssemblyTitle>
+    <VersionPrefix>1.0.0</VersionPrefix>
+    <AssemblyName>dotnet-xscgen</AssemblyName>
+    <RootNamespace>XmlSchemaClassGenerator.Console</RootNamespace>
+    <Authors>Michael Ganss</Authors>
+    <PackageId>dotnet-xscgen-csproj</PackageId>
+    <PackageTags>xsd xmlschema generator</PackageTags>
+    <PackageProjectUrl>https://github.com/mganss/XmlSchemaClassGenerator</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/mganss/XmlSchemaClassGenerator/blob/master/LICENSE</PackageLicenseUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>git://github.com/mganss/XmlSchemaClassGenerator</RepositoryUrl>
+    <ToolCommandName>dotnet-xscgen</ToolCommandName>
+    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\XmlSchemaClassGenerator\XmlSchemaClassGenerator.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\XmlSchemaClassGenerator.Console\**\*.cs" Exclude="..\XmlSchemaClassGenerator.Console\obj\**\*;..\XmlSchemaClassGenerator.Console\bin\**\*" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Glob.cs" Version="2.0.13" />
+    <PackageReference Include="Mono.Options" Version="5.3.0.1" />
+  </ItemGroup>
+  <PropertyGroup>
+    <SonarQubeExclude>true</SonarQubeExclude>
+  </PropertyGroup>
+</Project>

--- a/xscgen-proj/xscgen-proj.csproj
+++ b/xscgen-proj/xscgen-proj.csproj
@@ -9,7 +9,7 @@
     <AssemblyName>dotnet-xscgen</AssemblyName>
     <RootNamespace>XmlSchemaClassGenerator.Console</RootNamespace>
     <Authors>Michael Ganss</Authors>
-    <PackageId>dotnet-xscgen-csproj</PackageId>
+    <PackageId>dotnet-xscgen-proj</PackageId>
     <PackageTags>xsd xmlschema generator</PackageTags>
     <PackageProjectUrl>https://github.com/mganss/XmlSchemaClassGenerator</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/mganss/XmlSchemaClassGenerator/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
Added a new version that is NOT a .NET Global Tool, and called it `dotnet-xscgen.csproj`. This supports project-level CLI tooling by refencing `dotnet-xscgen-csproj` as a `DotNetCliToolReference`.

> It is important to note, that to make this work, a small bug fix was required in the `XmlSchemaClassGenerator-beta` package, which was swapping the order of the values in the  `TargetFrameworks` element to `netstandard2.0;net45` instead of `net45;netstandard2.0`

This functionality will allow us to use the tool inside a project-level context, for example:
```xml
<Project Sdk="Microsoft.NET.Sdk">

  <PropertyGroup>
    <TargetFramework>netstandard2.0</TargetFramework>
  </PropertyGroup>
  <Target Name="PrecompileScript" BeforeTargets="BeforeBuild">
    <Exec Command="dotnet xscgen *.xsd" />
  </Target>

  <ItemGroup>
    <DotNetCliToolReference Include="dotnet-xscgen-csproj" Version="1.0.0" />
  </ItemGroup>
</Project>
```