### PR TITLE
Internal visiblility

### DIFF
--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -209,6 +209,11 @@ namespace XmlSchemaClassGenerator
 
             interfaceDeclaration.IsInterface = true;
             interfaceDeclaration.IsPartial = true;
+            if (Configuration.AssemblyVisible)
+            {
+                interfaceDeclaration.TypeAttributes = (interfaceDeclaration.TypeAttributes & ~System.Reflection.TypeAttributes.VisibilityMask) | System.Reflection.TypeAttributes.NestedAssembly;
+            }
+
 
             foreach (var property in Properties)
                 property.AddInterfaceMembersTo(interfaceDeclaration);
@@ -1126,6 +1131,10 @@ namespace XmlSchemaClassGenerator
             GenerateTypeAttribute(enumDeclaration);
 
             enumDeclaration.IsEnum = true;
+            if (Configuration.AssemblyVisible)
+            {
+                enumDeclaration.TypeAttributes = (enumDeclaration.TypeAttributes & ~System.Reflection.TypeAttributes.VisibilityMask) | System.Reflection.TypeAttributes.NestedAssembly;
+            }
 
             foreach (var val in Values)
             {


### PR DESCRIPTION
I noticed that I implemented AssemblyVisible only for classes. `enum` and `interfaces` are still `public`.

This change should fix that, but one of the new tests fails because of `SourceUri` property is empty string on `attributeGroupRef`. I don't think this has something todo with the changes I did. But parse operation in the test that I use wrong.  
The xml from the text comes from a project where it is working, so that should be fine.

If someone can give me a hint what I need to change so the last test passes I would appreciate that.