### PR TITLE
Handle "0-1" definitions of boolean in .xsd

### DIFF
--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -1264,7 +1264,18 @@ namespace XmlSchemaClassGenerator
             {
                 var rv = new CodeMethodInvokeExpression(new CodeTypeReferenceExpression(typeof(DateTime)), "Parse", new CodePrimitiveExpression(defaultString));
                 return rv;
-            }
+            } 
+			else if (type == typeof(Boolean) && !String.IsNullOrEmpty(defaultString) && !String.IsNullOrWhiteSpace(defaultString)) { 
+				if (defaultString == "0") {
+					//alternate false
+					return new CodePrimitiveExpression(false);
+				} else if (defaultString == "1") {
+					return new CodePrimitiveExpression(true);
+				} else {
+					return new CodePrimitiveExpression(Convert.ChangeType(defaultString, ValueType));
+				}
+			}
+
 
             return new CodePrimitiveExpression(Convert.ChangeType(defaultString, ValueType));
         }


### PR DESCRIPTION
Hello.  I've been doing C# development for a variety of XML services, and I occasionally encounter a schema definition that uses numeral 1 or 0 to define true/false.

I recently have been working on a project that uses that same kind of schema definition, and your utility has been able to handle complex, interlocking definitions a lot better than any other FOSS tool that I've come across.  However, I had to make this small change to complete the code generation.

I'm submitting this PR in order to give back to the project.  