### PR TITLE
Customizable private member prefix.

### DIFF
--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -131,7 +131,7 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 GenerateDebuggerStepThroughAttribute = generateDebuggerStepThroughAttribute,
                 DisableComments = disableComments,
                 GenerateDescriptionAttribute = generateDescriptionAttribute,
-                DoNotUseUnderscoreInPrivateMemberNames = doNotUseUnderscoreInPrivateMemberNames,
+                PrivateMemberPrefix = doNotUseUnderscoreInPrivateMemberNames ? "" : "_",
                 EnableUpaCheck = enableUpaCheck
             };
 

--- a/XmlSchemaClassGenerator/CodeUtilities.cs
+++ b/XmlSchemaClassGenerator/CodeUtilities.cs
@@ -27,9 +27,9 @@ namespace XmlSchemaClassGenerator
             return char.ToLowerInvariant(s[0]) + s.Substring(1);
         }
 
-        public static string ToBackingField(this string propertyName, bool doNotUseUnderscoreInPrivateMemberNames)
+        public static string ToBackingField(this string propertyName, string privateFieldPrefix)
         {
-            return doNotUseUnderscoreInPrivateMemberNames ? propertyName.ToCamelCase() : string.Concat("_", propertyName.ToCamelCase());
+            return string.Concat(privateFieldPrefix, propertyName.ToCamelCase());
         }
 
         public static bool? IsDataTypeAttributeAllowed(this XmlSchemaDatatype type, GeneratorConfiguration configuration)
@@ -226,7 +226,7 @@ namespace XmlSchemaClassGenerator
         public static string GetUniqueFieldName(this TypeModel typeModel, PropertyModel propertyModel)
         {
             var classModel = typeModel as ClassModel;
-            var propBackingFieldName = propertyModel.Name.ToBackingField(classModel?.Configuration.DoNotUseUnderscoreInPrivateMemberNames == true);
+            var propBackingFieldName = propertyModel.Name.ToBackingField(classModel?.Configuration.PrivateMemberPrefix);
 
             if (CSharpKeywords.Contains(propBackingFieldName.ToLower()))
                 propBackingFieldName = "@" + propBackingFieldName;
@@ -250,7 +250,7 @@ namespace XmlSchemaClassGenerator
                     break;
                 }
 
-                var backingFieldName = prop.Name.ToBackingField(classModel.Configuration.DoNotUseUnderscoreInPrivateMemberNames);
+                var backingFieldName = prop.Name.ToBackingField(classModel.Configuration.PrivateMemberPrefix);
                 if (backingFieldName == propBackingFieldName)
                 {
                     i += 1;

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -193,10 +193,10 @@ namespace XmlSchemaClassGenerator
             set { _configuration.DisableComments = value; }
         }
 
-        public bool DoNotUseUnderscoreInPrivateMemberNames
+        public string PrivateMemberPrefix
         {
-            get { return _configuration.DoNotUseUnderscoreInPrivateMemberNames; }
-            set { _configuration.DoNotUseUnderscoreInPrivateMemberNames = value; }
+            get { return _configuration.PrivateMemberPrefix; }
+            set { _configuration.PrivateMemberPrefix = value; }
         }
 
         public bool EnableUpaCheck

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -174,7 +174,8 @@ namespace XmlSchemaClassGenerator
         public NamingProvider NamingProvider { get; set; }
 
         public bool DisableComments { get; set; }
-        public bool DoNotUseUnderscoreInPrivateMemberNames { get; set; }
+
+        public string PrivateMemberPrefix { get; set; } = "_";
 
         /// <summary>
         /// Check for Unique Particle Attribution (UPA) violations

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -333,7 +333,7 @@ namespace XmlSchemaClassGenerator
 
                     if (Configuration.EnableDataBinding)
                     {
-                        var backingFieldMember = new CodeMemberField(typeReference, member.Name.ToBackingField(Configuration.DoNotUseUnderscoreInPrivateMemberNames))
+                        var backingFieldMember = new CodeMemberField(typeReference, member.Name.ToBackingField(Configuration.PrivateMemberPrefix))
                         {
                             Attributes = MemberAttributes.Private
                         };


### PR DESCRIPTION
Instead of having an option to add underscore or not, let the user directly specify which prefix they want.