### PR TITLE
Add interface for NamingProvider and expand its use.

### DIFF
--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -18,7 +18,7 @@ namespace XmlSchemaClassGenerator
             set { _configuration.NamespaceProvider = value; }
         }
 
-        public NamingProvider NamingProvider
+        public INamingProvider NamingProvider
         {
             get { return _configuration.NamingProvider; }
             set { _configuration.NamingProvider = value; }

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -171,7 +171,7 @@ namespace XmlSchemaClassGenerator
         /// <summary>
         /// Provides options to customize Elementnamens with own logik
         /// </summary>
-        public NamingProvider NamingProvider { get; set; }
+        public INamingProvider NamingProvider { get; set; }
 
         public bool DisableComments { get; set; }
         public bool DoNotUseUnderscoreInPrivateMemberNames { get; set; }

--- a/XmlSchemaClassGenerator/INamingProvider.cs
+++ b/XmlSchemaClassGenerator/INamingProvider.cs
@@ -1,0 +1,47 @@
+﻿namespace XmlSchemaClassGenerator
+{
+    using System.Xml;
+
+    public interface INamingProvider
+    {
+        /// <summary>
+        /// Creates a name for a property from an attribute name
+        /// </summary>
+        /// <param name="typeModelName">Name of the typeModel</param>
+        /// <param name="attributeName">Attribute name</param>
+        /// <returns>Name of the property</returns>
+        string PropertyNameFromAttribute(string typeModelName, string attributeName);
+
+        /// <summary>
+        /// Creates a name for a property from an element name
+        /// </summary>
+        /// <param name="typeModelName">Name of the typeModel</param>
+        /// <param name="elementName">Element name</param>
+        /// <returns>Name of the property</returns>
+        string PropertyNameFromElement(string typeModelName, string elementName);
+
+        /// <summary>
+        /// Creates a name for an enum member based on a value
+        /// </summary>
+        /// <param name="enumName">Name of the enum</param>
+        /// <param name="value">Value name</param>
+        /// <returns>Name of the enum member</returns>
+        string EnumMemberNameFromValue(string enumName, string value);
+
+        string ComplexTypeNameFromQualifiedName(XmlQualifiedName qualifiedName);
+
+        string AttributeGroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName);
+
+        string GroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName);
+
+        string SimpleTypeNameFromQualifiedName(XmlQualifiedName qualifiedName);
+
+        string RootClassNameFromQualifiedName(XmlQualifiedName qualifiedName);
+
+        string EnumTypeNameFromQualifiedName(XmlQualifiedName qualifiedName);
+
+        string AttributeNameFromQualifiedName(XmlQualifiedName qualifiedName);
+
+        string ElementNameFromQualifiedName(XmlQualifiedName qualifiedName);
+    }
+}

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -53,7 +53,7 @@ namespace XmlSchemaClassGenerator
 
             foreach (var rootElement in set.GlobalElements.Values.Cast<XmlSchemaElement>())
             {
-	            var rootSchema = rootElement.GetSchema();
+                var rootSchema = rootElement.GetSchema();
                 var source = CodeUtilities.CreateUri(rootSchema.SourceUri);
                 var qualifiedName = rootElement.ElementSchemaType.QualifiedName;
                 if (qualifiedName.IsEmpty) { qualifiedName = rootElement.QualifiedName; }
@@ -68,7 +68,7 @@ namespace XmlSchemaClassGenerator
 
                         var derivedClassModel = new ClassModel(_configuration)
                         {
-                            Name = ToTitleCase(rootElement.QualifiedName.Name),
+                            Name = _configuration.NamingProvider.RootClassNameFromQualifiedName(rootElement.QualifiedName),
                             Namespace = CreateNamespaceModel(source, rootElement.QualifiedName)
                         };
 
@@ -145,7 +145,7 @@ namespace XmlSchemaClassGenerator
 
         private TypeModel CreateTypeModel(Uri source, XmlSchemaGroup group, NamespaceModel namespaceModel, XmlQualifiedName qualifiedName, List<DocumentationModel> docs)
         {
-            var name = "I" + ToTitleCase(qualifiedName.Name);
+            var name = "I" + _configuration.NamingProvider.GroupTypeNameFromQualifiedName(qualifiedName);
             if (namespaceModel != null) { name = namespaceModel.GetUniqueTypeName(name); }
 
             var interfaceModel = new InterfaceModel(_configuration)
@@ -173,7 +173,7 @@ namespace XmlSchemaClassGenerator
 
         private TypeModel CreateTypeModel(Uri source, XmlSchemaAttributeGroup attributeGroup, NamespaceModel namespaceModel, XmlQualifiedName qualifiedName, List<DocumentationModel> docs)
         {
-            var name = "I" + ToTitleCase(qualifiedName.Name);
+            var name = "I" + _configuration.NamingProvider.AttributeGroupTypeNameFromQualifiedName(qualifiedName);
             if (namespaceModel != null) { name = namespaceModel.GetUniqueTypeName(name); }
 
             var interfaceModel = new InterfaceModel(_configuration)
@@ -200,7 +200,7 @@ namespace XmlSchemaClassGenerator
 
         private TypeModel CreateTypeModel(Uri source, XmlSchemaComplexType complexType, NamespaceModel namespaceModel, XmlQualifiedName qualifiedName, List<DocumentationModel> docs)
         {
-            var name = ToTitleCase(qualifiedName.Name);
+            var name = _configuration.NamingProvider.ComplexTypeNameFromQualifiedName(qualifiedName);
             if (namespaceModel != null)
             {
                 name = namespaceModel.GetUniqueTypeName(name);
@@ -321,7 +321,7 @@ namespace XmlSchemaClassGenerator
                 if (isEnum)
                 {
                     // we got an enum
-                    var name = ToTitleCase(qualifiedName.Name);
+                    var name = _configuration.NamingProvider.EnumTypeNameFromQualifiedName(qualifiedName);
                     if (namespaceModel != null) { name = namespaceModel.GetUniqueTypeName(name); }
 
                     var enumModel = new EnumModel(_configuration)
@@ -368,7 +368,7 @@ namespace XmlSchemaClassGenerator
                 restrictions = GetRestrictions(typeRestriction.Facets.Cast<XmlSchemaFacet>(), simpleType).Where(r => r != null).Sanitize().ToList();
             }
 
-            var simpleModelName = ToTitleCase(qualifiedName.Name);
+            var simpleModelName = _configuration.NamingProvider.SimpleTypeNameFromQualifiedName(qualifiedName);
             if (namespaceModel != null) { simpleModelName = namespaceModel.GetUniqueTypeName(simpleModelName); }
 
             var simpleModel = new SimpleModel(_configuration)
@@ -404,7 +404,7 @@ namespace XmlSchemaClassGenerator
                     if (attribute.Use != XmlSchemaUse.Prohibited)
                     {
                         var attributeQualifiedName = attribute.AttributeSchemaType.QualifiedName;
-                        var attributeName = ToTitleCase(attribute.QualifiedName.Name);
+                        var attributeName = _configuration.NamingProvider.AttributeNameFromQualifiedName(attribute.QualifiedName);
 
                         if (attribute.Parent is XmlSchemaAttributeGroup attributeGroup && attributeGroup.QualifiedName != typeModel.XmlSchemaName && Types.TryGetValue(attributeGroup.QualifiedName, out var typeModelValue) && typeModelValue is InterfaceModel interfaceTypeModel)
                         {
@@ -507,7 +507,7 @@ namespace XmlSchemaClassGenerator
                         }
                     }
 
-                    var propertyName = ToTitleCase(element.QualifiedName.Name);
+                    var propertyName = _configuration.NamingProvider.ElementNameFromQualifiedName(element.QualifiedName);
                     if (propertyName == typeModel.Name)
                     {
                         propertyName += "Property"; // member names cannot be the same as their enclosing type
@@ -717,11 +717,6 @@ namespace XmlSchemaClassGenerator
             }
 
             throw new ArgumentException(string.Format("Namespace {0} not provided through map or generator.", xmlNamespace));
-        }
-
-        private string ToTitleCase(string s)
-        {
-            return s.ToTitleCase(_configuration.NamingScheme);
         }
     }
 }

--- a/XmlSchemaClassGenerator/NamingProvider.cs
+++ b/XmlSchemaClassGenerator/NamingProvider.cs
@@ -57,9 +57,9 @@
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public string ComplexTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string ComplexTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
         {
-            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+            return QualifiedNameToTitleCase(qualifiedName);
         }
 
         /// <summary>
@@ -67,9 +67,9 @@
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public string AttributeGroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string AttributeGroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
         {
-            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+            return QualifiedNameToTitleCase(qualifiedName);
         }
 
         /// <summary>
@@ -77,9 +77,9 @@
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public string GroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string GroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
         {
-            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+            return QualifiedNameToTitleCase(qualifiedName);
         }
 
         /// <summary>
@@ -87,9 +87,9 @@
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public string SimpleTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string SimpleTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
         {
-            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+            return QualifiedNameToTitleCase(qualifiedName);
         }
 
         /// <summary>
@@ -97,9 +97,9 @@
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public string RootClassNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string RootClassNameFromQualifiedName(XmlQualifiedName qualifiedName)
         {
-            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+            return QualifiedNameToTitleCase(qualifiedName);
         }
 
         /// <summary>
@@ -107,9 +107,9 @@
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public string EnumTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string EnumTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
         {
-            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+            return QualifiedNameToTitleCase(qualifiedName);
         }
 
         /// <summary>
@@ -117,9 +117,9 @@
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public string AttributeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string AttributeNameFromQualifiedName(XmlQualifiedName qualifiedName)
         {
-            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+            return QualifiedNameToTitleCase(qualifiedName);
         }
 
         /// <summary>
@@ -127,9 +127,19 @@
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public string ElementNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string ElementNameFromQualifiedName(XmlQualifiedName qualifiedName)
         {
-            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+            return QualifiedNameToTitleCase(qualifiedName);
+        }
+
+        /// <summary>
+        /// Used internally to make the QualifiedName have the desired naming schema.
+        /// </summary>
+        /// <param name="qualifiedName">Not null element.</param>
+        /// <returns>A string formatted as desired.</returns>
+        protected virtual string QualifiedNameToTitleCase(XmlQualifiedName qualifiedName)
+        {
+            return qualifiedName.Name.ToTitleCase(_namingScheme);
         }
     }
 }

--- a/XmlSchemaClassGenerator/NamingProvider.cs
+++ b/XmlSchemaClassGenerator/NamingProvider.cs
@@ -1,9 +1,12 @@
 ﻿namespace XmlSchemaClassGenerator
 {
+    using System.Xml;
+
     /// <summary>
     /// Provides options to customize member names
     /// </summary>
     public class NamingProvider
+        : INamingProvider
     {
         private readonly NamingScheme _namingScheme;
 
@@ -47,6 +50,86 @@
         public virtual string EnumMemberNameFromValue(string enumName, string value)
         {
             return value.ToTitleCase(_namingScheme).ToNormalizedEnumName();
+        }
+
+        /// <summary>
+        /// Define the name to be used when a ComplexType is found in the XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        public string ComplexTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        {
+            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+        }
+
+        /// <summary>
+        /// Define the name to be used when a AttributeGroup is found in the XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        public string AttributeGroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        {
+            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+        }
+
+        /// <summary>
+        /// Define the name to be used when a GroupType is found in the XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        public string GroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        {
+            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+        }
+
+        /// <summary>
+        /// Define the name to be used when a SimpleType is found in the XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        public string SimpleTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        {
+            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+        }
+
+        /// <summary>
+        /// Define the name to be used for the root class.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        public string RootClassNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        {
+            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+        }
+
+        /// <summary>
+        /// Define the name to be used when an enum type is found in the XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        public string EnumTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        {
+            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+        }
+
+        /// <summary>
+        /// Define the name to be used when an attribute is found in the XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        public string AttributeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        {
+            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
+        }
+
+        /// <summary>
+        /// Define the name of the C# class property from the element name in XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        public string ElementNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        {
+            return qualifiedName.Name.ToTitleCase(NamingScheme.PascalCase);
         }
     }
 }


### PR DESCRIPTION
Use INamingProvider to also be able to change the class names from their
names in the XSD.

The idea is to be able to change the name of the whole class if necessary.
For example remove all underscores.