### PR TITLE
Make EmitOrder work for arrays. Fixes #126

### DIFF
--- a/XmlSchemaClassGenerator.Tests/Compiler.cs
+++ b/XmlSchemaClassGenerator.Tests/Compiler.cs
@@ -102,7 +102,8 @@ namespace XmlSchemaClassGenerator.Tests
                 MemberVisitor = generatorPrototype.MemberVisitor,
                 GenerateDescriptionAttribute = generatorPrototype.GenerateDescriptionAttribute,
                 CodeTypeReferenceOptions = generatorPrototype.CodeTypeReferenceOptions,
-                TextValuePropertyName = generatorPrototype.TextValuePropertyName
+                TextValuePropertyName = generatorPrototype.TextValuePropertyName,
+                EmitOrder = generatorPrototype.EmitOrder
             };
 
             gen.Generate(files);

--- a/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
+++ b/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
@@ -179,6 +179,9 @@
     <None Update="xml\tradeSite_min.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="xsd\array-order\array-order.xsd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="xsd\client\client.xsd">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -71,6 +71,7 @@ namespace XmlSchemaClassGenerator.Tests
         const string WadlPattern = @"xsd\wadl\*.xsd";
         const string ListPattern = @"xsd\list\list.xsd";
         const string SimplePattern = @"xsd\simple\simple.xsd";
+        const string ArrayOrderPattern = @"xsd\array-order\array-order.xsd";
         const string ClientPattern = @"xsd\client\client.xsd";
         const string IataPattern = @"xsd\iata\*.xsd";
         const string TimePattern = @"xsd\time\time.xsd";
@@ -129,6 +130,18 @@ namespace XmlSchemaClassGenerator.Tests
                 CodeTypeReferenceOptions = CodeTypeReferenceOptions.GlobalReference
             });
             TestSamples("Simple", SimplePattern);
+        }
+
+        [Fact, TestPriority(1)]
+        [UseCulture("en-US")]
+        public void TestArrayOrder()
+        {
+            Compiler.Generate("ArrayOrder", ArrayOrderPattern, new Generator
+            {
+                NamespacePrefix = "ArrayOrder",
+                EmitOrder = true
+            });
+            TestSamples("ArrayOrder", ArrayOrderPattern);
         }
 
         [Fact, TestPriority(1)]

--- a/XmlSchemaClassGenerator.Tests/xsd/array-order/array-order.xsd
+++ b/XmlSchemaClassGenerator.Tests/xsd/array-order/array-order.xsd
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+	<xs:element name="P">
+		<xs:complexType>
+			<xs:sequence>
+        <xs:element name="A" type="xs:string"/>
+				<xs:element name="B" type="Q" minOccurs="0"/>
+				<xs:element name="C" type="xs:string"/>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+	<xs:complexType name="Q">
+		<xs:sequence>
+			<xs:element name="R" maxOccurs="unbounded">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name="D" type="xs:string" minOccurs="0"/>
+					</xs:sequence>
+				</xs:complexType>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>
+

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -1048,8 +1048,11 @@ namespace XmlSchemaClassGenerator
             }
             else
             {
-                attributes.Add(new CodeAttributeDeclaration(new CodeTypeReference(typeof(XmlArrayAttribute), Configuration.CodeTypeReferenceOptions),
-                    new CodeAttributeArgument(new CodePrimitiveExpression(XmlSchemaName.Name))));
+                var arrayAttribute = new CodeAttributeDeclaration(new CodeTypeReference(typeof(XmlArrayAttribute), Configuration.CodeTypeReferenceOptions),
+                    new CodeAttributeArgument(new CodePrimitiveExpression(XmlSchemaName.Name)));
+                if (Order != null)
+                    arrayAttribute.Arguments.Add(new CodeAttributeArgument("Order", new CodePrimitiveExpression(Order.Value)));
+                attributes.Add(arrayAttribute);
             }
 
             foreach (var attribute in attributes)


### PR DESCRIPTION
The actual fix I've made is a small modification to `XmlSchemaClassGenerator/TypeModel.cs`. If you have time to check it out and merge, I'd really appreciate it.

It probably needs checking by someone more familiar with the code, to make sure I've done it the _right way_.

Another potential I discovered in the process is in `XmlSchemaClassGenerator.Tests/Compiler.cs`. The generator `gen` is constructed with some fields from the `generatorPrototype`, but not all. I've added `EmitOrder` (which is needed to make the test fail on the old version). Maybe this should be updated to exhaustively copy all fields, or maybe it's better to just add them as needed.

Thanks :)