### PR TITLE
Fix for wrong namespace specification of XML element attribute of derived types

### DIFF
--- a/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
+++ b/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
@@ -71,6 +71,9 @@
     <None Update="xml\assistedLiving_min.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="xml\bpmnSimple.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Update="xml\compulsoryAuction_max.xml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
@@ -180,6 +183,21 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="xsd\array-order\array-order.xsd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="xsd\bpmn\BPMN20.xsd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="xsd\bpmn\BPMNDI.xsd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="xsd\bpmn\DC.xsd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="xsd\bpmn\DI.xsd">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="xsd\bpmn\Semantic.xsd">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
     <None Update="xsd\client\client.xsd">
@@ -470,5 +488,8 @@
     <None Update="xsd\time\time.xsd">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="xsd\bpmn\" />
   </ItemGroup>
 </Project>

--- a/XmlSchemaClassGenerator.Tests/xml/bpmnSimple.xml
+++ b/XmlSchemaClassGenerator.Tests/xml/bpmnSimple.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1dhbs6d" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.1.2">
+  <bpmn:process id="Process_1szwmzf" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start&#10;&#10;">
+      <bpmn:outgoing>SequenceFlow_15dil8x</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:task id="Task_0hzgmx7" name="Action">
+      <bpmn:incoming>SequenceFlow_15dil8x</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_1k24n4s</bpmn:outgoing>
+    </bpmn:task>
+    <bpmn:endEvent id="EndEvent_0covrtz" name="End">
+      <bpmn:incoming>SequenceFlow_1k24n4s</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_15dil8x" sourceRef="StartEvent_1" targetRef="Task_0hzgmx7" />
+    <bpmn:sequenceFlow id="SequenceFlow_1k24n4s" sourceRef="Task_0hzgmx7" targetRef="EndEvent_0covrtz" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1szwmzf">
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="185" y="146" width="25" height="40" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Task_0hzgmx7_di" bpmnElement="Task_0hzgmx7">
+        <dc:Bounds x="276" y="81" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0covrtz_di" bpmnElement="EndEvent_0covrtz">
+        <dc:Bounds x="444" y="103" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="452" y="146" width="20" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_15dil8x_di" bpmnElement="SequenceFlow_15dil8x">
+        <di:waypoint x="215" y="121" />
+        <di:waypoint x="276" y="121" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="SequenceFlow_1k24n4s_di" bpmnElement="SequenceFlow_1k24n4s">
+        <di:waypoint x="376" y="121" />
+        <di:waypoint x="444" y="121" />
+      </bpmndi:BPMNEdge>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/XmlSchemaClassGenerator.Tests/xsd/bpmn/BPMN20.xsd
+++ b/XmlSchemaClassGenerator.Tests/xsd/bpmn/BPMN20.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified"	
+	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+	xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI"
+	targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+
+	<xsd:import namespace="http://www.omg.org/spec/BPMN/20100524/DI" schemaLocation="BPMNDI.xsd"/>
+	<xsd:include schemaLocation="Semantic.xsd"/>
+
+	<xsd:element name="definitions" type="tDefinitions"/>
+	<xsd:complexType name="tDefinitions">
+		<xsd:sequence>
+			<xsd:element ref="import" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="extension" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="rootElement" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="bpmndi:BPMNDiagram" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="relationship" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="name" type="xsd:string"/>
+		<xsd:attribute name="targetNamespace" type="xsd:anyURI" use="required"/>
+		<xsd:attribute name="expressionLanguage" type="xsd:anyURI" use="optional" default="http://www.w3.org/1999/XPath"/>
+		<xsd:attribute name="typeLanguage" type="xsd:anyURI" use="optional" default="http://www.w3.org/2001/XMLSchema"/>
+		<xsd:attribute name="exporter" type="xsd:string"/>
+		<xsd:attribute name="exporterVersion" type="xsd:string"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	
+	<xsd:element name="import" type="tImport"/>
+	<xsd:complexType name="tImport">
+		<xsd:attribute name="namespace" type="xsd:anyURI" use="required"/>
+		<xsd:attribute name="location" type="xsd:string" use="required"/>
+		<xsd:attribute name="importType" type="xsd:anyURI" use="required"/>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/XmlSchemaClassGenerator.Tests/xsd/bpmn/BPMNDI.xsd
+++ b/XmlSchemaClassGenerator.Tests/xsd/bpmn/BPMNDI.xsd
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" targetNamespace="http://www.omg.org/spec/BPMN/20100524/DI"  elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.omg.org/spec/DD/20100524/DC" schemaLocation="DC.xsd" />
+	<xsd:import namespace="http://www.omg.org/spec/DD/20100524/DI" schemaLocation="DI.xsd" />
+	
+	<xsd:element name="BPMNDiagram" type="bpmndi:BPMNDiagram" />
+	<xsd:element name="BPMNPlane" type="bpmndi:BPMNPlane" />
+	<xsd:element name="BPMNLabelStyle" type="bpmndi:BPMNLabelStyle" />
+	<xsd:element name="BPMNShape" type="bpmndi:BPMNShape" substitutionGroup="di:DiagramElement" />
+	<xsd:element name="BPMNLabel" type="bpmndi:BPMNLabel" />
+	<xsd:element name="BPMNEdge" type="bpmndi:BPMNEdge" substitutionGroup="di:DiagramElement" />
+	
+	<xsd:complexType name="BPMNDiagram">
+		<xsd:complexContent>
+			<xsd:extension base="di:Diagram">
+				<xsd:sequence>
+					<xsd:element ref="bpmndi:BPMNPlane" />
+					<xsd:element ref="bpmndi:BPMNLabelStyle" maxOccurs="unbounded" minOccurs="0" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType name="BPMNPlane">
+		<xsd:complexContent>
+			<xsd:extension base="di:Plane">
+				<xsd:attribute name="bpmnElement" type="xsd:QName" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType name="BPMNEdge">
+		<xsd:complexContent>
+			<xsd:extension base="di:LabeledEdge">
+				<xsd:sequence>
+					<xsd:element ref="bpmndi:BPMNLabel" minOccurs="0" />
+				</xsd:sequence>
+				<xsd:attribute name="bpmnElement" type="xsd:QName" />
+				<xsd:attribute name="sourceElement" type="xsd:QName" />
+				<xsd:attribute name="targetElement" type="xsd:QName" />
+				<xsd:attribute name="messageVisibleKind" type="bpmndi:MessageVisibleKind" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType name="BPMNShape">
+		<xsd:complexContent>
+			<xsd:extension base="di:LabeledShape">
+				<xsd:sequence>
+					<xsd:element ref="bpmndi:BPMNLabel" minOccurs="0" />
+				</xsd:sequence>
+				<xsd:attribute name="bpmnElement" type="xsd:QName" />
+				<xsd:attribute name="isHorizontal" type="xsd:boolean" />
+				<xsd:attribute name="isExpanded" type="xsd:boolean" />
+				<xsd:attribute name="isMarkerVisible" type="xsd:boolean" />
+				<xsd:attribute name="isMessageVisible" type="xsd:boolean" />
+				<xsd:attribute name="participantBandKind" type="bpmndi:ParticipantBandKind" />
+        		<xsd:attribute name="choreographyActivityShape" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType name="BPMNLabel">
+		<xsd:complexContent>
+			<xsd:extension base="di:Label">
+				<xsd:attribute name="labelStyle" type="xsd:QName" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType name="BPMNLabelStyle">
+		<xsd:complexContent>
+			<xsd:extension base="di:Style">
+				<xsd:sequence>
+					<xsd:element ref="dc:Font" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="ParticipantBandKind">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="top_initiating" />
+			<xsd:enumeration value="middle_initiating" />
+			<xsd:enumeration value="bottom_initiating" />
+			<xsd:enumeration value="top_non_initiating" />
+			<xsd:enumeration value="middle_non_initiating" />
+			<xsd:enumeration value="bottom_non_initiating" />
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:simpleType name="MessageVisibleKind">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="initiating" />
+			<xsd:enumeration value="non_initiating" />
+		</xsd:restriction>
+	</xsd:simpleType>
+
+</xsd:schema>

--- a/XmlSchemaClassGenerator.Tests/xsd/bpmn/DC.xsd
+++ b/XmlSchemaClassGenerator.Tests/xsd/bpmn/DC.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" targetNamespace="http://www.omg.org/spec/DD/20100524/DC" elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:element name="Font" type="dc:Font" />
+	<xsd:element name="Point" type="dc:Point" />
+	<xsd:element name="Bounds" type="dc:Bounds" />
+	
+	<xsd:complexType name="Font">
+		<xsd:attribute name="name" type="xsd:string" />
+		<xsd:attribute name="size" type="xsd:double" />
+		<xsd:attribute name="isBold" type="xsd:boolean" />
+		<xsd:attribute name="isItalic" type="xsd:boolean" />
+		<xsd:attribute name="isUnderline" type="xsd:boolean" />
+		<xsd:attribute name="isStrikeThrough" type="xsd:boolean" />
+	</xsd:complexType>
+	
+	<xsd:complexType name="Point">
+		<xsd:attribute name="x" type="xsd:double" use="required" />
+		<xsd:attribute name="y" type="xsd:double" use="required" />
+	</xsd:complexType>
+	
+	<xsd:complexType name="Bounds">
+		<xsd:attribute name="x" type="xsd:double" use="required" />
+		<xsd:attribute name="y" type="xsd:double" use="required" />
+		<xsd:attribute name="width" type="xsd:double" use="required" />
+		<xsd:attribute name="height" type="xsd:double" use="required" />
+	</xsd:complexType>
+
+</xsd:schema>

--- a/XmlSchemaClassGenerator.Tests/xsd/bpmn/DI.xsd
+++ b/XmlSchemaClassGenerator.Tests/xsd/bpmn/DI.xsd
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" targetNamespace="http://www.omg.org/spec/DD/20100524/DI" elementFormDefault="qualified" attributeFormDefault="unqualified">
+
+	<xsd:import namespace="http://www.omg.org/spec/DD/20100524/DC" schemaLocation="DC.xsd" />
+	
+	<xsd:element name="DiagramElement" type="di:DiagramElement" />
+	<xsd:element name="Diagram" type="di:Diagram" />
+	<xsd:element name="Style" type="di:Style" />
+	<xsd:element name="Node" type="di:Node" />
+	<xsd:element name="Edge" type="di:Edge" />
+	<xsd:element name="Shape" type="di:Shape" />
+	<xsd:element name="Plane" type="di:Plane" />
+	<xsd:element name="LabeledEdge" type="di:LabeledEdge" />
+	<xsd:element name="Label" type="di:Label" />
+	<xsd:element name="LabeledShape" type="di:LabeledShape" />
+	
+	<xsd:complexType abstract="true" name="DiagramElement">
+		<xsd:sequence>
+			<xsd:element name="extension" minOccurs="0">
+				<xsd:complexType>
+					<xsd:sequence>
+						<xsd:any namespace="##other" minOccurs="0" maxOccurs="unbounded" />
+					</xsd:sequence>
+				</xsd:complexType>
+			</xsd:element>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" />
+		<xsd:anyAttribute namespace="##other" processContents="lax" />
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Diagram">
+		<xsd:attribute name="name" type="xsd:string" />
+		<xsd:attribute name="documentation" type="xsd:string" />
+		<xsd:attribute name="resolution" type="xsd:double" />
+		<xsd:attribute name="id" type="xsd:ID" />
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Node">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement" />
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Edge">
+		<xsd:complexContent>
+			<xsd:extension base="di:DiagramElement">
+				<xsd:sequence>
+					<xsd:element maxOccurs="unbounded" minOccurs="2" name="waypoint" type="dc:Point" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="LabeledEdge">
+		<xsd:complexContent>
+			<xsd:extension base="di:Edge" />
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Shape">
+		<xsd:complexContent>
+			<xsd:extension base="di:Node">
+				<xsd:sequence>
+					<xsd:element ref="dc:Bounds" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="LabeledShape">
+		<xsd:complexContent>
+			<xsd:extension base="di:Shape" />
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Label">
+		<xsd:complexContent>
+			<xsd:extension base="di:Node">
+				<xsd:sequence>
+					<xsd:element ref="dc:Bounds" minOccurs="0" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Plane">
+		<xsd:complexContent>
+			<xsd:extension base="di:Node">
+				<xsd:sequence>
+					<xsd:element ref="di:DiagramElement" maxOccurs="unbounded" minOccurs="0" />
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:complexType abstract="true" name="Style">
+		<xsd:attribute name="id" type="xsd:ID" />
+	</xsd:complexType>
+	
+</xsd:schema>

--- a/XmlSchemaClassGenerator.Tests/xsd/bpmn/Semantic.xsd
+++ b/XmlSchemaClassGenerator.Tests/xsd/bpmn/Semantic.xsd
@@ -1,0 +1,1562 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema elementFormDefault="qualified" attributeFormDefault="unqualified"
+	xmlns="http://www.omg.org/spec/BPMN/20100524/MODEL" 
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" 
+	targetNamespace="http://www.omg.org/spec/BPMN/20100524/MODEL">
+	
+	<xsd:element name="activity" type="tActivity"/>
+	<xsd:complexType name="tActivity" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowNode">
+				<xsd:sequence>
+					<xsd:element ref="ioSpecification" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dataInputAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dataOutputAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="resourceRole" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="loopCharacteristics" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="isForCompensation" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="startQuantity" type="xsd:integer" default="1"/>
+				<xsd:attribute name="completionQuantity" type="xsd:integer" default="1"/>
+				<xsd:attribute name="default" type="xsd:IDREF" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="adHocSubProcess" type="tAdHocSubProcess" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tAdHocSubProcess">
+		<xsd:complexContent>
+			<xsd:extension base="tSubProcess">
+				<xsd:sequence>
+					<xsd:element name="completionCondition" type="tExpression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="cancelRemainingInstances" type="xsd:boolean" default="true"/>
+				<xsd:attribute name="ordering" type="tAdHocOrdering"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="tAdHocOrdering">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Parallel"/>
+			<xsd:enumeration value="Sequential"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+
+	<xsd:element name="artifact" type="tArtifact"/>
+	<xsd:complexType name="tArtifact" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="assignment" type="tAssignment" />
+	<xsd:complexType name="tAssignment">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="from" type="tExpression" minOccurs="1" maxOccurs="1"/>
+					<xsd:element name="to" type="tExpression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="association" type="tAssociation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:attribute name="sourceRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="targetRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="associationDirection" type="tAssociationDirection" default="None"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="tAssociationDirection">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="One"/>
+			<xsd:enumeration value="Both"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:element name="auditing" type="tAuditing"/>
+	<xsd:complexType name="tAuditing">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="baseElement" type="tBaseElement"/>
+	<xsd:complexType name="tBaseElement" abstract="true">
+		<xsd:sequence>
+			<xsd:element ref="documentation" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="extensionElements" minOccurs="0" maxOccurs="1" /> 
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+	
+	<xsd:element name="baseElementWithMixedContent" type="tBaseElementWithMixedContent"/>
+	<xsd:complexType name="tBaseElementWithMixedContent" abstract="true" mixed="true">
+		<xsd:sequence>
+			<xsd:element ref="documentation" minOccurs="0" maxOccurs="unbounded"/>
+			<xsd:element ref="extensionElements" minOccurs="0" maxOccurs="1" /> 
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:anyAttribute namespace="##other" processContents="lax"/>
+	</xsd:complexType>
+
+	<xsd:element name="boundaryEvent" type="tBoundaryEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tBoundaryEvent">
+		<xsd:complexContent>
+			<xsd:extension base="tCatchEvent">
+				<xsd:attribute name="cancelActivity" type="xsd:boolean" default="true"/>
+				<xsd:attribute name="attachedToRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>			
+
+	<xsd:element name="businessRuleTask" type="tBusinessRuleTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tBusinessRuleTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask">
+				<xsd:attribute name="implementation" type="tImplementation" default="##unspecified"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="callableElement" type="tCallableElement"/>
+	<xsd:complexType name="tCallableElement">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element name="supportedInterfaceRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="ioSpecification" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="ioBinding" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="callActivity" type="tCallActivity" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tCallActivity">
+		<xsd:complexContent>
+			<xsd:extension base="tActivity">
+				<xsd:attribute name="calledElement" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="callChoreography" type="tCallChoreography" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tCallChoreography">
+		<xsd:complexContent>
+			<xsd:extension base="tChoreographyActivity">
+				<xsd:sequence>
+					<xsd:element ref="participantAssociation" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="calledChoreographyRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="callConversation" type="tCallConversation" substitutionGroup="conversationNode"/>
+	<xsd:complexType name="tCallConversation">
+		<xsd:complexContent>
+			<xsd:extension base="tConversationNode">
+				<xsd:sequence>
+					<xsd:element ref="participantAssociation" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="calledCollaborationRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="cancelEventDefinition" type="tCancelEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tCancelEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="catchEvent" type="tCatchEvent"/>
+	<xsd:complexType name="tCatchEvent" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tEvent">
+				<xsd:sequence>
+					<xsd:element ref="dataOutput" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dataOutputAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="outputSet" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="eventDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="eventDefinitionRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="parallelMultiple" type="xsd:boolean" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="category" type="tCategory" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tCategory">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="categoryValue" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="categoryValue" type="tCategoryValue"/>
+	<xsd:complexType name="tCategoryValue">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="value" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="choreography" type="tChoreography" substitutionGroup="collaboration"/>
+	<xsd:complexType name="tChoreography">
+		<xsd:complexContent>
+			<xsd:extension base="tCollaboration">
+				<xsd:sequence>
+					<xsd:element ref="flowElement" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="choreographyActivity" type="tChoreographyActivity"/>
+	<xsd:complexType name="tChoreographyActivity" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowNode">
+				<xsd:sequence>
+					<xsd:element name="participantRef" type="xsd:QName" minOccurs="2" maxOccurs="unbounded"/>
+					<xsd:element ref="correlationKey" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="initiatingParticipantRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="loopType" type="tChoreographyLoopType" default="None"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="tChoreographyLoopType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="Standard"/>
+			<xsd:enumeration value="MultiInstanceSequential"/>
+			<xsd:enumeration value="MultiInstanceParallel"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	
+	<xsd:element name="choreographyTask" type="tChoreographyTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tChoreographyTask">
+		<xsd:complexContent>
+			<xsd:extension base="tChoreographyActivity">
+				<xsd:sequence>
+					<xsd:element name="messageFlowRef" type="xsd:QName" minOccurs="1" maxOccurs="2"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="collaboration" type="tCollaboration" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tCollaboration">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="participant" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="messageFlow" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="conversationNode" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="conversationAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="participantAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="messageFlowAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="correlationKey" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="choreographyRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="conversationLink" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="isClosed" type="xsd:boolean" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="compensateEventDefinition" type="tCompensateEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tCompensateEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:attribute name="waitForCompletion" type="xsd:boolean"/>
+				<xsd:attribute name="activityRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="complexBehaviorDefinition" type="tComplexBehaviorDefinition"/>
+	<xsd:complexType name="tComplexBehaviorDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="condition" type="tFormalExpression" minOccurs="1" maxOccurs="1"/>
+					<xsd:element name="event" type="tImplicitThrowEvent" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="complexGateway" type="tComplexGateway" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tComplexGateway">
+		<xsd:complexContent>
+			<xsd:extension base="tGateway">
+				<xsd:sequence>
+					<xsd:element name="activationCondition" type="tExpression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="default" type="xsd:IDREF"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="conditionalEventDefinition" type="tConditionalEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tConditionalEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:sequence>
+					<xsd:element name="condition" type="tExpression"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="conversation" type="tConversation" substitutionGroup="conversationNode"/>
+	<xsd:complexType name="tConversation">
+		<xsd:complexContent>
+			<xsd:extension base="tConversationNode"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="conversationAssociation" type="tConversationAssociation"/>
+	<xsd:complexType name="tConversationAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="innerConversationNodeRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="outerConversationNodeRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="conversationLink" type="tConversationLink"/> 
+	<xsd:complexType name="tConversationLink"> 
+		<xsd:complexContent> 
+			<xsd:extension base="tBaseElement"> 
+				<xsd:attribute name="name" type="xsd:string" use="optional"/> 
+				<xsd:attribute name="sourceRef" type="xsd:QName" use="required"/> 
+				<xsd:attribute name="targetRef" type="xsd:QName" use="required"/> 
+			</xsd:extension> 
+		</xsd:complexContent> 
+	</xsd:complexType>
+  
+	<xsd:element name="conversationNode" type="tConversationNode"/>
+	<xsd:complexType name="tConversationNode" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="participantRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="messageFlowRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="correlationKey" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="correlationKey" type="tCorrelationKey"/>
+	<xsd:complexType name="tCorrelationKey">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="correlationPropertyRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="correlationProperty" type="tCorrelationProperty" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tCorrelationProperty">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="correlationPropertyRetrievalExpression" minOccurs="1" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="type" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="correlationPropertyBinding" type="tCorrelationPropertyBinding"/>
+	<xsd:complexType name="tCorrelationPropertyBinding">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="dataPath" type="tFormalExpression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="correlationPropertyRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="correlationPropertyRetrievalExpression" type="tCorrelationPropertyRetrievalExpression"/>
+	<xsd:complexType name="tCorrelationPropertyRetrievalExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="messagePath" type="tFormalExpression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="messageRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="correlationSubscription" type="tCorrelationSubscription"/>
+	<xsd:complexType name="tCorrelationSubscription">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="correlationPropertyBinding" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="correlationKeyRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="dataAssociation" type="tDataAssociation" />
+	<xsd:complexType name="tDataAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="sourceRef" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="targetRef" type="xsd:IDREF" minOccurs="1" maxOccurs="1"/>
+					<xsd:element name="transformation" type="tFormalExpression" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="assignment" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="dataInput" type="tDataInput" />
+	<xsd:complexType name="tDataInput">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName" />
+				<xsd:attribute name="isCollection" type="xsd:boolean" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataInputAssociation" type="tDataInputAssociation" />
+	<xsd:complexType name="tDataInputAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tDataAssociation"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataObject" type="tDataObject" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tDataObject">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
+				<xsd:attribute name="isCollection" type="xsd:boolean" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataObjectReference" type="tDataObjectReference" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tDataObjectReference">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
+				<xsd:attribute name="dataObjectRef" type="xsd:IDREF"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataOutput" type="tDataOutput" />
+	<xsd:complexType name="tDataOutput">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="optional" />
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
+				<xsd:attribute name="isCollection" type="xsd:boolean" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataOutputAssociation" type="tDataOutputAssociation" />
+	<xsd:complexType name="tDataOutputAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tDataAssociation"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataState" type="tDataState" />
+	<xsd:complexType name="tDataState">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataStore" type="tDataStore" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tDataStore">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="capacity" type="xsd:integer"/>
+				<xsd:attribute name="isUnlimited" type="xsd:boolean" default="true"/>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="dataStoreReference" type="tDataStoreReference" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tDataStoreReference">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
+				<xsd:attribute name="dataStoreRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="documentation" type="tDocumentation"/>
+	<xsd:complexType name="tDocumentation" mixed="true">
+		<xsd:sequence>
+			<xsd:any namespace="##any" processContents="lax" minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="id" type="xsd:ID" use="optional"/>
+		<xsd:attribute name="textFormat" type="xsd:string" default="text/plain"/>
+	</xsd:complexType>
+	
+	<xsd:element name="endEvent" type="tEndEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tEndEvent">
+		<xsd:complexContent>
+			<xsd:extension base="tThrowEvent"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="endPoint" type="tEndPoint" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tEndPoint">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>		
+	
+	<xsd:element name="error" type="tError" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tError">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="errorCode" type="xsd:string"/>
+				<xsd:attribute name="structureRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="errorEventDefinition" type="tErrorEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tErrorEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:attribute name="errorRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="escalation" type="tEscalation" substitutionGroup="rootElement"/>	
+	<xsd:complexType name="tEscalation">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="escalationCode" type="xsd:string"/>
+				<xsd:attribute name="structureRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="escalationEventDefinition" type="tEscalationEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tEscalationEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:attribute name="escalationRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="event" type="tEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tEvent" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowNode">
+				<xsd:sequence>
+					<xsd:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="eventBasedGateway" type="tEventBasedGateway" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tEventBasedGateway">
+		<xsd:complexContent>
+			<xsd:extension base="tGateway">
+				<xsd:attribute name="instantiate" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="eventGatewayType" type="tEventBasedGatewayType" default="Exclusive"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:simpleType name="tEventBasedGatewayType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Exclusive"/>
+			<xsd:enumeration value="Parallel"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+
+	<xsd:element name="eventDefinition" type="tEventDefinition" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tEventDefinition" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>			
+
+	<xsd:element name="exclusiveGateway" type="tExclusiveGateway" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tExclusiveGateway">
+		<xsd:complexContent>
+			<xsd:extension base="tGateway">
+				<xsd:attribute name="default" type="xsd:IDREF" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="expression" type="tExpression"/>
+	<xsd:complexType name="tExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElementWithMixedContent"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="extension" type="tExtension"/>
+	<xsd:complexType name="tExtension">
+		<xsd:sequence>
+			<xsd:element ref="documentation" minOccurs="0" maxOccurs="unbounded"/>
+		</xsd:sequence>
+		<xsd:attribute name="definition" type="xsd:QName"/>
+		<xsd:attribute name="mustUnderstand" type="xsd:boolean" use="optional" default="false"/>
+	</xsd:complexType>
+	
+	<xsd:element name="extensionElements" type="tExtensionElements" /> 
+	<xsd:complexType name="tExtensionElements">
+		<xsd:sequence>
+			<xsd:any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded" /> 
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:element name="flowElement" type="tFlowElement"/>
+	<xsd:complexType name="tFlowElement" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="auditing" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="monitoring" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="categoryValueRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="flowNode" type="tFlowNode"/>
+	<xsd:complexType name="tFlowNode" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element name="incoming" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="outgoing" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="formalExpression" type="tFormalExpression" substitutionGroup="expression"/>
+	<xsd:complexType name="tFormalExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tExpression">
+				<xsd:attribute name="language" type="xsd:anyURI" use="optional"/>
+				<xsd:attribute name="evaluatesToTypeRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="gateway" type="tGateway" abstract="true"/>
+	<xsd:complexType name="tGateway">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowNode">
+				<xsd:attribute name="gatewayDirection" type="tGatewayDirection" default="Unspecified"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:simpleType name="tGatewayDirection">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Unspecified"/>
+			<xsd:enumeration value="Converging"/>
+			<xsd:enumeration value="Diverging"/>
+			<xsd:enumeration value="Mixed"/>
+		</xsd:restriction>
+	</xsd:simpleType>	
+	
+	<xsd:element name="globalBusinessRuleTask" type="tGlobalBusinessRuleTask" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tGlobalBusinessRuleTask">
+		<xsd:complexContent>
+			<xsd:extension base="tGlobalTask">
+				<xsd:attribute name="implementation" type="tImplementation" default="##unspecified"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="globalChoreographyTask" type="tGlobalChoreographyTask" substitutionGroup="choreography"/>
+	<xsd:complexType name="tGlobalChoreographyTask">
+		<xsd:complexContent>
+			<xsd:extension base="tChoreography">
+				<xsd:attribute name="initiatingParticipantRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:element name="globalConversation" type="tGlobalConversation" substitutionGroup="collaboration"/>
+	<xsd:complexType name="tGlobalConversation">
+		<xsd:complexContent>
+			<xsd:extension base="tCollaboration"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="globalManualTask" type="tGlobalManualTask" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tGlobalManualTask">
+		<xsd:complexContent>
+			<xsd:extension base="tGlobalTask"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="globalScriptTask" type="tGlobalScriptTask"  substitutionGroup="rootElement"/>
+	<xsd:complexType name="tGlobalScriptTask">
+		<xsd:complexContent>
+			<xsd:extension base="tGlobalTask">
+				<xsd:sequence>
+					<xsd:element ref="script" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="scriptLanguage" type="xsd:anyURI"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="globalTask" type="tGlobalTask" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tGlobalTask">
+		<xsd:complexContent>
+			<xsd:extension base="tCallableElement">
+				<xsd:sequence>
+					<xsd:element ref="resourceRole" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="globalUserTask" type="tGlobalUserTask" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tGlobalUserTask">
+		<xsd:complexContent>
+			<xsd:extension base="tGlobalTask">
+				<xsd:sequence>
+					<xsd:element ref="rendering" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="implementation" type="tImplementation" default="##unspecified"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="group" type="tGroup" substitutionGroup="artifact"/>
+	<xsd:complexType name="tGroup">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:attribute name="categoryValueRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="humanPerformer" type="tHumanPerformer" substitutionGroup="performer"/>
+	<xsd:complexType name="tHumanPerformer">
+		<xsd:complexContent>
+			<xsd:extension base="tPerformer"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:simpleType name="tImplementation">
+		<xsd:union memberTypes="xsd:anyURI">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:token">
+					<xsd:enumeration value="##unspecified" /> 
+					<xsd:enumeration value="##WebService" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:union>
+	</xsd:simpleType>
+
+	<xsd:element name="implicitThrowEvent" type="tImplicitThrowEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tImplicitThrowEvent">
+		<xsd:complexContent>
+			<xsd:extension base="tThrowEvent"/>
+		</xsd:complexContent>
+	</xsd:complexType>				
+	
+	<xsd:element name="inclusiveGateway" type="tInclusiveGateway" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tInclusiveGateway">
+		<xsd:complexContent>
+			<xsd:extension base="tGateway">
+				<xsd:attribute name="default" type="xsd:IDREF" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="inputSet" type="tInputSet" />
+	<xsd:complexType name="tInputSet">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="dataInputRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="optionalInputRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="whileExecutingInputRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="outputSetRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" />
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="interface" type="tInterface" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tInterface">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="operation" minOccurs="1" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+				<xsd:attribute name="implementationRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="intermediateCatchEvent" type="tIntermediateCatchEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tIntermediateCatchEvent">
+		<xsd:complexContent>
+			<xsd:extension base="tCatchEvent"/>
+		</xsd:complexContent>
+	</xsd:complexType>			
+
+	<xsd:element name="intermediateThrowEvent" type="tIntermediateThrowEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tIntermediateThrowEvent">
+		<xsd:complexContent>
+			<xsd:extension base="tThrowEvent"/>
+		</xsd:complexContent>
+	</xsd:complexType>				
+
+	<xsd:element name="ioBinding" type="tInputOutputBinding" />
+	<xsd:complexType name="tInputOutputBinding">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="operationRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="inputDataRef" type="xsd:IDREF" use="required"/>
+				<xsd:attribute name="outputDataRef" type="xsd:IDREF" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="ioSpecification" type="tInputOutputSpecification" />
+	<xsd:complexType name="tInputOutputSpecification">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="dataInput" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dataOutput" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="inputSet" minOccurs="1" maxOccurs="unbounded"/>
+					<xsd:element ref="outputSet" minOccurs="1" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="itemDefinition" type="tItemDefinition" substitutionGroup="rootElement"/>	
+	<xsd:complexType name="tItemDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:attribute name="structureRef" type="xsd:QName"/>
+				<xsd:attribute name="isCollection" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="itemKind" type="tItemKind" default="Information"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>		
+	
+	<xsd:simpleType name="tItemKind">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="Information"/>
+			<xsd:enumeration value="Physical"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:element name="lane" type="tLane"/>
+	<xsd:complexType name="tLane">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="partitionElement" type="tBaseElement" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="flowNodeRef" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="childLaneSet" type="tLaneSet" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="partitionElementRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="laneSet" type="tLaneSet"/>
+	<xsd:complexType name="tLaneSet">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="lane" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="linkEventDefinition" type="tLinkEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tLinkEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:sequence>
+					<xsd:element name="source" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="target" type="xsd:QName" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="loopCharacteristics" type="tLoopCharacteristics"/>
+	<xsd:complexType name="tLoopCharacteristics" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="manualTask" type="tManualTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tManualTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="message" type="tMessage" substitutionGroup="rootElement"/>	
+	<xsd:complexType name="tMessage">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="itemRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>		
+	
+	<xsd:element name="messageEventDefinition" type="tMessageEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tMessageEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:sequence>
+					<xsd:element name="operationRef" type="xsd:QName" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="messageRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="messageFlow" type="tMessageFlow"/>
+	<xsd:complexType name="tMessageFlow">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="name" type="xsd:string" use="optional"/>
+				<xsd:attribute name="sourceRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="targetRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="messageRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="messageFlowAssociation" type="tMessageFlowAssociation"/>
+	<xsd:complexType name="tMessageFlowAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="innerMessageFlowRef" type="xsd:QName" use="required"/>
+				<xsd:attribute name="outerMessageFlowRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="monitoring" type="tMonitoring"/>
+	<xsd:complexType name="tMonitoring">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="multiInstanceLoopCharacteristics" type="tMultiInstanceLoopCharacteristics"  substitutionGroup="loopCharacteristics"/>
+	<xsd:complexType name="tMultiInstanceLoopCharacteristics">
+		<xsd:complexContent>
+			<xsd:extension base="tLoopCharacteristics">
+				<xsd:sequence>
+					<xsd:element name="loopCardinality" type="tExpression" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="loopDataInputRef" type="xsd:QName" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="loopDataOutputRef" type="xsd:QName" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="inputDataItem" type="tDataInput" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="outputDataItem" type="tDataOutput" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="complexBehaviorDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="completionCondition" type="tExpression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="isSequential" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="behavior" type="tMultiInstanceFlowCondition" default="All"/>
+				<xsd:attribute name="oneBehaviorEventRef" type="xsd:QName" use="optional"/>
+				<xsd:attribute name="noneBehaviorEventRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:simpleType name="tMultiInstanceFlowCondition">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="One"/>
+			<xsd:enumeration value="All"/>
+			<xsd:enumeration value="Complex"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:element name="operation" type="tOperation"/>
+	<xsd:complexType name="tOperation">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="inMessageRef" type="xsd:QName" minOccurs="1" maxOccurs="1"/>
+					<xsd:element name="outMessageRef" type="xsd:QName" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="errorRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+				<xsd:attribute name="implementationRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="outputSet" type="tOutputSet" />
+	<xsd:complexType name="tOutputSet">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="dataOutputRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="optionalOutputRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="whileExecutingOutputRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="inputSetRefs" type="xsd:IDREF" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="parallelGateway" type="tParallelGateway" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tParallelGateway">
+		<xsd:complexContent>
+			<xsd:extension base="tGateway"/>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="participant" type="tParticipant"/>
+	<xsd:complexType name="tParticipant">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="interfaceRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="endPointRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="participantMultiplicity" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="processRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="participantAssociation" type="tParticipantAssociation"/>
+	<xsd:complexType name="tParticipantAssociation">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="innerParticipantRef" type="xsd:QName" minOccurs="1" maxOccurs="1"/>
+					<xsd:element name="outerParticipantRef" type="xsd:QName" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="participantMultiplicity" type="tParticipantMultiplicity"/>
+	<xsd:complexType name="tParticipantMultiplicity">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="minimum" type="xsd:int" default="0"/>
+				<xsd:attribute name="maximum" type="xsd:int" default="1"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="partnerEntity" type="tPartnerEntity" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tPartnerEntity">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element name="participantRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="partnerRole" type="tPartnerRole" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tPartnerRole">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element name="participantRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="performer" type="tPerformer" substitutionGroup="resourceRole"/>
+	<xsd:complexType name="tPerformer">
+		<xsd:complexContent>
+			<xsd:extension base="tResourceRole"/>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="potentialOwner" type="tPotentialOwner" substitutionGroup="performer"/>
+	<xsd:complexType name="tPotentialOwner">
+		<xsd:complexContent>
+			<xsd:extension base="tHumanPerformer"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="process" type="tProcess" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tProcess">
+		<xsd:complexContent>
+			<xsd:extension base="tCallableElement">
+				<xsd:sequence>
+					<xsd:element ref="auditing" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="monitoring" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="property" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="laneSet" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="flowElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="resourceRole" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="correlationSubscription" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="supports" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="processType" type="tProcessType" default="None"/>
+				<xsd:attribute name="isClosed" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="isExecutable" type="xsd:boolean"/>
+				<xsd:attribute name="definitionalCollaborationRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="tProcessType">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="Public"/>
+			<xsd:enumeration value="Private"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+
+	<xsd:element name="property" type="tProperty" />
+	<xsd:complexType name="tProperty">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="dataState" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="itemSubjectRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="receiveTask" type="tReceiveTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tReceiveTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask">
+				<xsd:attribute name="implementation" type="tImplementation" default="##WebService"/>
+				<xsd:attribute name="instantiate" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="messageRef" type="xsd:QName" use="optional"/>
+				<xsd:attribute name="operationRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="relationship" type="tRelationship"/>
+	<xsd:complexType name="tRelationship">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element name="source" type="xsd:QName" minOccurs="1" maxOccurs="unbounded"/>
+					<xsd:element name="target" type="xsd:QName" minOccurs="1" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="type" type="xsd:string" use="required"/>
+				<xsd:attribute name="direction" type="tRelationshipDirection"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:simpleType name="tRelationshipDirection">
+		<xsd:restriction base="xsd:string">
+			<xsd:enumeration value="None"/>
+			<xsd:enumeration value="Forward"/>
+			<xsd:enumeration value="Backward"/>
+			<xsd:enumeration value="Both"/>
+		</xsd:restriction>
+	</xsd:simpleType>
+	
+	<xsd:element name="rendering" type="tRendering"/>
+	<xsd:complexType name="tRendering">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="resource" type="tResource" substitutionGroup="rootElement"/>
+	<xsd:complexType name="tResource">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:sequence>
+					<xsd:element ref="resourceParameter" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="name" type="xsd:string" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="resourceAssignmentExpression" type="tResourceAssignmentExpression"/>
+	<xsd:complexType name="tResourceAssignmentExpression">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="expression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="resourceParameter" type="tResourceParameter"/>
+	<xsd:complexType name="tResourceParameter">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="type" type="xsd:QName"/>
+				<xsd:attribute name="isRequired" type="xsd:boolean"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="resourceParameterBinding" type="tResourceParameterBinding"/>
+	<xsd:complexType name="tResourceParameterBinding">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement">
+				<xsd:sequence>
+					<xsd:element ref="expression" minOccurs="1" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="parameterRef" type="xsd:QName" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="resourceRole" type="tResourceRole"/>
+	<xsd:complexType name="tResourceRole"> 
+		<xsd:complexContent> 
+			<xsd:extension base="tBaseElement"> 
+				<xsd:choice> 
+					<xsd:sequence> 
+						<xsd:element name="resourceRef" type="xsd:QName"/> 
+						<xsd:element ref="resourceParameterBinding" minOccurs="0" maxOccurs="unbounded"/> 
+					</xsd:sequence> 
+					<xsd:element ref="resourceAssignmentExpression" minOccurs="0" maxOccurs="1"/> 
+				</xsd:choice>
+				<xsd:attribute name="name" type="xsd:string"/>
+			</xsd:extension> 
+		</xsd:complexContent> 
+	</xsd:complexType>
+
+	<xsd:element name="rootElement" type="tRootElement"/>
+	<xsd:complexType name="tRootElement" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tBaseElement"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="scriptTask" type="tScriptTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tScriptTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask">
+				<xsd:sequence>
+					<xsd:element ref="script" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="scriptFormat" type="xsd:string"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>		
+	
+	<xsd:element name="script" type="tScript"/>
+	<xsd:complexType name="tScript" mixed="true">
+		<xsd:sequence>
+			<xsd:any namespace="##any" processContents="lax" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>	
+
+	<xsd:element name="sendTask" type="tSendTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tSendTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask">
+				<xsd:attribute name="implementation" type="tImplementation" default="##WebService"/>
+				<xsd:attribute name="messageRef" type="xsd:QName" use="optional"/>
+				<xsd:attribute name="operationRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="sequenceFlow" type="tSequenceFlow" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tSequenceFlow">
+		<xsd:complexContent>
+			<xsd:extension base="tFlowElement">
+				<xsd:sequence>
+					<xsd:element name="conditionExpression"  type="tExpression" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="sourceRef" type="xsd:IDREF" use="required"/>
+				<xsd:attribute name="targetRef" type="xsd:IDREF" use="required"/>
+				<xsd:attribute name="isImmediate" type="xsd:boolean" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="serviceTask" type="tServiceTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tServiceTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask">
+				<xsd:attribute name="implementation" type="tImplementation" default="##WebService"/>
+				<xsd:attribute name="operationRef" type="xsd:QName" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+	
+	<xsd:element name="signal" type="tSignal" substitutionGroup="rootElement"/>	
+	<xsd:complexType name="tSignal">
+		<xsd:complexContent>
+			<xsd:extension base="tRootElement">
+				<xsd:attribute name="name" type="xsd:string"/>
+				<xsd:attribute name="structureRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="signalEventDefinition" type="tSignalEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tSignalEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:attribute name="signalRef" type="xsd:QName"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="standardLoopCharacteristics" type="tStandardLoopCharacteristics"  substitutionGroup="loopCharacteristics"/>
+	<xsd:complexType name="tStandardLoopCharacteristics">
+		<xsd:complexContent>
+			<xsd:extension base="tLoopCharacteristics">
+				<xsd:sequence>
+					<xsd:element name="loopCondition" type="tExpression" minOccurs="0"/>
+				</xsd:sequence>
+				<xsd:attribute name="testBefore" type="xsd:boolean" default="false"/>
+				<xsd:attribute name="loopMaximum" type="xsd:integer" use="optional"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>	
+
+	<xsd:element name="startEvent" type="tStartEvent" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tStartEvent">
+		<xsd:complexContent>
+			<xsd:extension base="tCatchEvent">
+				<xsd:attribute name="isInterrupting" type="xsd:boolean" default="true"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>			
+	
+	<xsd:element name="subChoreography" type="tSubChoreography" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tSubChoreography">
+		<xsd:complexContent>
+			<xsd:extension base="tChoreographyActivity">
+				<xsd:sequence>
+					<xsd:element ref="flowElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="subConversation" type="tSubConversation" substitutionGroup="conversationNode"/>
+	<xsd:complexType name="tSubConversation">
+		<xsd:complexContent>
+			<xsd:extension base="tConversationNode">
+				<xsd:sequence>
+					<xsd:element ref="conversationNode" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="subProcess" type="tSubProcess" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tSubProcess">
+		<xsd:complexContent>
+			<xsd:extension base="tActivity">
+				<xsd:sequence>
+					<xsd:element ref="laneSet" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="flowElement" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="artifact" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="triggeredByEvent" type="xsd:boolean" default="false"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="task" type="tTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tTask">
+		<xsd:complexContent>
+			<xsd:extension base="tActivity"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:element name="terminateEventDefinition" type="tTerminateEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tTerminateEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition"/>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="textAnnotation" type="tTextAnnotation" substitutionGroup="artifact"/>
+	<xsd:complexType name="tTextAnnotation">
+		<xsd:complexContent>
+			<xsd:extension base="tArtifact">
+				<xsd:sequence>
+					<xsd:element ref="text" minOccurs="0" maxOccurs="1"/>
+				</xsd:sequence>
+				<xsd:attribute name="textFormat" type="xsd:string" default="text/plain"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="text" type="tText"/>
+	<xsd:complexType name="tText" mixed="true">
+		<xsd:sequence>
+			<xsd:any namespace="##any" processContents="lax" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+
+	<xsd:element name="throwEvent" type="tThrowEvent"/>
+	<xsd:complexType name="tThrowEvent" abstract="true">
+		<xsd:complexContent>
+			<xsd:extension base="tEvent">
+				<xsd:sequence>
+					<xsd:element ref="dataInput" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="dataInputAssociation" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element ref="inputSet" minOccurs="0" maxOccurs="1"/>
+					<xsd:element ref="eventDefinition" minOccurs="0" maxOccurs="unbounded"/>
+					<xsd:element name="eventDefinitionRef" type="xsd:QName" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>			
+	
+	<xsd:element name="timerEventDefinition" type="tTimerEventDefinition" substitutionGroup="eventDefinition"/>
+	<xsd:complexType name="tTimerEventDefinition">
+		<xsd:complexContent>
+			<xsd:extension base="tEventDefinition">
+				<xsd:choice>
+					<xsd:element name="timeDate" type="tExpression" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="timeDuration" type="tExpression" minOccurs="0" maxOccurs="1"/>
+					<xsd:element name="timeCycle" type="tExpression" minOccurs="0" maxOccurs="1"/>
+				</xsd:choice>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+	<xsd:element name="transaction" type="tTransaction" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tTransaction">
+		<xsd:complexContent>
+			<xsd:extension base="tSubProcess">
+				<xsd:attribute name="method" type="tTransactionMethod" default="##Compensate"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	
+	<xsd:simpleType name="tTransactionMethod">
+		<xsd:union memberTypes="xsd:anyURI">
+			<xsd:simpleType>
+				<xsd:restriction base="xsd:token">
+					<xsd:enumeration value="##Compensate" /> 
+					<xsd:enumeration value="##Image" />
+					<xsd:enumeration value="##Store" />
+				</xsd:restriction>
+			</xsd:simpleType>
+		</xsd:union>
+	</xsd:simpleType>
+
+	<xsd:element name="userTask" type="tUserTask" substitutionGroup="flowElement"/>
+	<xsd:complexType name="tUserTask">
+		<xsd:complexContent>
+			<xsd:extension base="tTask">
+				<xsd:sequence>
+					<xsd:element ref="rendering" minOccurs="0" maxOccurs="unbounded"/>
+				</xsd:sequence>
+				<xsd:attribute name="implementation" type="tImplementation" default="##unspecified"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+
+</xsd:schema>

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -1025,7 +1025,8 @@ namespace XmlSchemaClassGenerator
                         {
                             var derivedAttribute = new CodeAttributeDeclaration(new CodeTypeReference(typeof(XmlElementAttribute), Configuration.CodeTypeReferenceOptions),
                                 new CodeAttributeArgument(new CodePrimitiveExpression((derivedType.SubstitutionName ?? derivedType.XmlSchemaName).Name)),
-                                new CodeAttributeArgument("Type", new CodeTypeOfExpression(derivedType.GetReferenceFor(OwningType.Namespace))));
+                                new CodeAttributeArgument("Type", new CodeTypeOfExpression(derivedType.GetReferenceFor(OwningType.Namespace))),
+                                new CodeAttributeArgument("Namespace", new CodePrimitiveExpression(derivedType.XmlSchemaName.Namespace)));
                             if (Order != null)
                             {
                                 derivedAttribute.Arguments.Add(new CodeAttributeArgument("Order",
@@ -1056,19 +1057,23 @@ namespace XmlSchemaClassGenerator
 
             foreach (var attribute in attributes)
             {
-                if (XmlNamespace != null)
+                bool namespacePrecalculated = attribute.Arguments.OfType<CodeAttributeArgument>().Any(a => a.Name == "Namespace");
+                if (!namespacePrecalculated)
                 {
-                    attribute.Arguments.Add(new CodeAttributeArgument("Namespace", new CodePrimitiveExpression(XmlNamespace)));
-                }
-                else if (Form == XmlSchemaForm.Qualified)
-                {
-                    attribute.Arguments.Add(new CodeAttributeArgument("Namespace", new CodePrimitiveExpression(OwningType.XmlSchemaName.Namespace)));
-                }
-                else if (!IsAny)
-                {
-                    attribute.Arguments.Add(new CodeAttributeArgument("Form",
-                        new CodeFieldReferenceExpression(new CodeTypeReferenceExpression(new CodeTypeReference(typeof(XmlSchemaForm), Configuration.CodeTypeReferenceOptions)),
-                            "Unqualified")));
+                    if (XmlNamespace != null)
+                    {
+                        attribute.Arguments.Add(new CodeAttributeArgument("Namespace", new CodePrimitiveExpression(XmlNamespace)));
+                    }
+                    else if (Form == XmlSchemaForm.Qualified)
+                    {
+                        attribute.Arguments.Add(new CodeAttributeArgument("Namespace", new CodePrimitiveExpression(OwningType.XmlSchemaName.Namespace)));
+                    }
+                    else if (!IsAny)
+                    {
+                        attribute.Arguments.Add(new CodeAttributeArgument("Form",
+                            new CodeFieldReferenceExpression(new CodeTypeReferenceExpression(new CodeTypeReference(typeof(XmlSchemaForm), Configuration.CodeTypeReferenceOptions)),
+                                "Unqualified")));
+                    }
                 }
 
                 if (IsNillable)


### PR DESCRIPTION
The title is most probably very confusing and I apologize for that. I will try to explain the issue in the following lines :)
I was using the library for generating classes from BPMN standard xsd files.
However, I have noticed a problem with substitution groups in a circular type dependency scenario, when type defines an element of same owning type which is derived in an external namespace.

The example for this can be seen in BPMNDI.xsd and DI.xsd which specify: 
1. bpmndi:BPMNShape element with type=bpmndi:BPMNShape and substitution group=di:DiagramElement
2. di:DiagramElement complex type
3. di:Plane complex type specifying sub-element of di:DiagramElement type

Since BPMNShape (and also BPMNEdge) is a derived type from a different namespace Serialization.XmlElementAttribute for DiagramElement property of Plane class needs to include the namespace where BPMNShape is defined. Currently the namespace of the Plane type is used, which is incorrect.

I have provided a fix and also a test case which checks a very simple BPMN xml file which utilizes these types. The intention was not to test full BPMN spec, since it is a really large standard, but to solve this one problem with XML polymorphism.

Thanks! 

PS It might be that such definition of types is not allowed in the XSD standard, but it is used like that in BPMN specification. Let me know if you need more input for the exact source of the problem and further explanations. 
