### PR TITLE
Improving namespace provider to correctly generate custom csharp namespaces 

### DIFF
--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -117,7 +117,7 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 uris.AddRange(expandedGlob);
             }
 
-            var namespaceMap = namespaces.Select(n => ParseNamespace(n, namespacePrefix)).ToNamespaceProvider(key =>
+            var namespaceMap = namespaces.Select(n => Utility.ParseNamespace(n, namespacePrefix)).ToNamespaceProvider(key =>
             {
                 var xn = key.XmlSchemaNamespace;
                 var name = string.Join(".", xn.Split('/').Where(p => p != "schema" && GeneratorConfiguration.IdentifierRegex.IsMatch(p))
@@ -170,7 +170,21 @@ If no mapping is found for an XML namespace, a name is generated automatically (
             generator.Generate(uris);
         }
 
-        static KeyValuePair<NamespaceKey, string> ParseNamespace(string nsArg, string namespacePrefix)
+        static void ShowHelp(OptionSet p)
+        {
+            System.Console.WriteLine("Usage: dotnet xscgen [OPTIONS]+ xsdFile...");
+            System.Console.WriteLine("Generate C# classes from XML Schema files.");
+            System.Console.WriteLine("Version " + typeof(Generator).Assembly.GetName().Version);
+            System.Console.WriteLine(@"xsdFiles may contain globs, e.g. ""content\{schema,xsd}\**\*.xsd"", and URLs.");
+            System.Console.WriteLine(@"Append - to option to disable it, e.g. --interface-.");
+            System.Console.WriteLine();
+            System.Console.WriteLine("Options:");
+            p.WriteOptionDescriptions(System.Console.Out);
+        }
+    }
+    public static class Utility
+    {
+        public static KeyValuePair<NamespaceKey, string> ParseNamespace(string nsArg, string namespacePrefix)
         {
             var parts = nsArg.Split(new[] { '=' }, 2);
             var xmlNs = parts[0];
@@ -183,18 +197,6 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 netNs = namespacePrefix + "." + netNs;
             }
             return new KeyValuePair<NamespaceKey, string>(new NamespaceKey(source, xmlNs), netNs);
-        }
-
-        static void ShowHelp(OptionSet p)
-        {
-            System.Console.WriteLine("Usage: dotnet xscgen [OPTIONS]+ xsdFile...");
-            System.Console.WriteLine("Generate C# classes from XML Schema files.");
-            System.Console.WriteLine("Version " + typeof(Generator).Assembly.GetName().Version);
-            System.Console.WriteLine(@"xsdFiles may contain globs, e.g. ""content\{schema,xsd}\**\*.xsd"", and URLs.");
-            System.Console.WriteLine(@"Append - to option to disable it, e.g. --interface-.");
-            System.Console.WriteLine();
-            System.Console.WriteLine("Options:");
-            p.WriteOptionDescriptions(System.Console.Out);
         }
     }
 }

--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -117,7 +117,7 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 uris.AddRange(expandedGlob);
             }
 
-            var namespaceMap = namespaces.Select(n => Utility.ParseNamespace(n, namespacePrefix)).ToNamespaceProvider(key =>
+            var namespaceMap = namespaces.Select(n => CodeUtilities.ParseNamespace(n, namespacePrefix)).ToNamespaceProvider(key =>
             {
                 var xn = key.XmlSchemaNamespace;
                 var name = string.Join(".", xn.Split('/').Where(p => p != "schema" && GeneratorConfiguration.IdentifierRegex.IsMatch(p))
@@ -180,23 +180,6 @@ If no mapping is found for an XML namespace, a name is generated automatically (
             System.Console.WriteLine();
             System.Console.WriteLine("Options:");
             p.WriteOptionDescriptions(System.Console.Out);
-        }
-    }
-    public static class Utility
-    {
-        public static KeyValuePair<NamespaceKey, string> ParseNamespace(string nsArg, string namespacePrefix)
-        {
-            var parts = nsArg.Split(new[] { '=' }, 2);
-            var xmlNs = parts[0];
-            var netNs = parts[1];
-            var parts2 = xmlNs.Split(new[] { '|' }, 2);
-            var source = parts2.Length == 2 ? new Uri(parts2[1], UriKind.RelativeOrAbsolute) : null;
-            xmlNs = parts2[0];
-            if (!string.IsNullOrEmpty(namespacePrefix))
-            {
-                netNs = namespacePrefix + "." + netNs;
-            }
-            return new KeyValuePair<NamespaceKey, string>(new NamespaceKey(source, xmlNs), netNs);
         }
     }
 }

--- a/XmlSchemaClassGenerator.Tests/NamespaceProviderTests.cs
+++ b/XmlSchemaClassGenerator.Tests/NamespaceProviderTests.cs
@@ -63,5 +63,43 @@ namespace XmlSchemaClassGenerator.Tests
             Assert.False(new NamespaceKey("http://test") <= null);
             Assert.True(new NamespaceKey("http://test") != null);
         }
+
+        [Theory]
+        [InlineData("http://www.w3.org/2001/XMLSchema", "test.xsd", "MyNamespace", "Test")]
+        [InlineData("http://www.w3.org/2001/XMLSchema", "test.xsd", "MyNamespace", null)]
+        [InlineData("http://www.w3.org/2001/XMLSchema", "test.xsd", "MyNamespace", "")]
+        [InlineData("", "test.xsd", "MyNamespace", "Test")]
+        [InlineData("", "test.xsd", "MyNamespace", null)]
+        [InlineData("", "test.xsd", "MyNamespace", "")]
+        [InlineData(null, "test.xsd", "MyNamespace", "Test")]
+        [InlineData(null, "test.xsd", "MyNamespace", null)]
+        [InlineData(null, "test.xsd", "MyNamespace", "")]
+        public void TestParseNamespaceUtilityMethod1(string xmlNs, string xmlSchema, string netNs, string netPrefix)
+        {
+            string customNsPattern = "{0}|{1}={2}";
+
+            var uri = new Uri(xmlSchema, UriKind.RelativeOrAbsolute);
+            var fullNetNs = (string.IsNullOrEmpty(netPrefix)) ? netNs : string.Join('.', netPrefix, netNs);
+
+            var expected = new KeyValuePair<NamespaceKey, string>(new NamespaceKey(uri, xmlNs), fullNetNs);
+            var actual = CodeUtilities.ParseNamespace(string.Format(customNsPattern, xmlNs, xmlSchema, netNs), netPrefix);
+
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData("test.xsd", "MyNamespace", "Test")]
+        [InlineData("test.xsd", "MyNamespace", null)]
+        [InlineData("test.xsd", "MyNamespace", "")]
+        public void TestParseNamespaceUtilityMethod2(string xmlSchema, string netNs, string netPrefix)
+        {
+            string customNsPattern = "{0}={1}";
+
+            var fullNetNs = (string.IsNullOrEmpty(netPrefix)) ? netNs : string.Join('.', netPrefix, netNs);
+            var expected = new KeyValuePair<NamespaceKey, string>(new NamespaceKey(null, xmlSchema), fullNetNs);
+            var actual = CodeUtilities.ParseNamespace(string.Format(customNsPattern, xmlSchema, netNs), netPrefix);
+
+            Assert.Equal(expected, actual);
+        }
     }
 }

--- a/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
+++ b/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
@@ -21,7 +21,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\XmlSampleGenerator\XmlSampleGenerator.csproj" />
-    <ProjectReference Include="..\XmlSchemaClassGenerator.Console\XmlSchemaClassGenerator.Console.csproj" />
     <ProjectReference Include="..\XmlSchemaClassGenerator\XmlSchemaClassGenerator.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
+++ b/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\XmlSampleGenerator\XmlSampleGenerator.csproj" />
+    <ProjectReference Include="..\XmlSchemaClassGenerator.Console\XmlSchemaClassGenerator.Console.csproj" />
     <ProjectReference Include="..\XmlSchemaClassGenerator\XmlSchemaClassGenerator.csproj" />
   </ItemGroup>
   <ItemGroup>

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -14,7 +14,6 @@ using System.Xml.XPath;
 using Ganss.IO;
 using Microsoft.CodeAnalysis;
 using Microsoft.Xml.XMLGen;
-using XmlSchemaClassGenerator.Console;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -408,7 +407,7 @@ namespace XmlSchemaClassGenerator.Tests
                 DataAnnotationMode = DataAnnotationMode.All,
                 GenerateNullables = true,
                 MemberVisitor = (member, model) => { },
-                NamespaceProvider = customNamespaceConfig.Select(n => Utility.ParseNamespace(n, null)).ToNamespaceProvider()
+                NamespaceProvider = customNamespaceConfig.Select(n => CodeUtilities.ParseNamespace(n, null)).ToNamespaceProvider()
             });
             Assert.NotNull(assembly);
 

--- a/XmlSchemaClassGenerator/CodeUtilities.cs
+++ b/XmlSchemaClassGenerator/CodeUtilities.cs
@@ -297,5 +297,20 @@ namespace XmlSchemaClassGenerator
         };
 
         internal static Uri CreateUri(string uri) => string.IsNullOrEmpty(uri) ? null : new Uri(uri);
+
+        public static KeyValuePair<NamespaceKey, string> ParseNamespace(string nsArg, string namespacePrefix)
+        {
+            var parts = nsArg.Split(new[] { '=' }, 2);
+            var xmlNs = parts[0];
+            var netNs = parts[1];
+            var parts2 = xmlNs.Split(new[] { '|' }, 2);
+            var source = parts2.Length == 2 ? new Uri(parts2[1], UriKind.RelativeOrAbsolute) : null;
+            xmlNs = parts2[0];
+            if (!string.IsNullOrEmpty(namespacePrefix))
+            {
+                netNs = namespacePrefix + "." + netNs;
+            }
+            return new KeyValuePair<NamespaceKey, string>(new NamespaceKey(source, xmlNs), netNs);
+        }
     }
 }

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -69,8 +69,9 @@ namespace XmlSchemaClassGenerator
             {
                 foreach (var import in imports)
                 {
-                    ResolveDependencies(import.Schema, dependencyOrder);
-                }                
+                    if (import.Schema != null)
+                        ResolveDependencies(import.Schema, dependencyOrder);
+                }
             }
             dependencyOrder.Add(schema);
         }

--- a/XmlSchemaClassGenerator/NamespaceProvider.cs
+++ b/XmlSchemaClassGenerator/NamespaceProvider.cs
@@ -158,6 +158,9 @@ namespace XmlSchemaClassGenerator
                 var path = key.Source.IsAbsoluteUri ? key.Source.LocalPath : key.Source.OriginalString;
                 keyValues.Add(new NamespaceKey(new Uri(Path.GetFileName(path), UriKind.Relative)));
 
+                // Search for both file name and XmlSchemaNamespace pair
+                keyValues.Add(new NamespaceKey(new Uri(Path.GetFileName(path), UriKind.Relative), key.XmlSchemaNamespace));
+
                 // Search for XmlSchemaNamespace only
                 keyValues.Add(new NamespaceKey(key.XmlSchemaNamespace));
 


### PR DESCRIPTION
Namespace provider did not work correctly in cases when defined types have dependencies from other namespaces i.e. imported xsds.

This has been resolved by adding simple dependency resolver of imported schemas in ModelBuilder by prioritizing type creation from leaf schemas up to the root of the dependency tree.

Unit test is also provided to test this issue.