### PR TITLE
enable splitting into namespace and filename - separately.

### DIFF
--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -21,6 +21,7 @@ namespace XmlSchemaClassGenerator.Console
             var showHelp = args.Length == 0;
             var namespaces = new List<string>();
             var outputFolder = (string)null;
+            var splitNamespaceAndFileName = false;
             var integerType = typeof(string);
             var namespacePrefix = "";
             var verbose = false;
@@ -52,6 +53,9 @@ One option must be given for each namespace to be mapped.
 A file name may be given by appending a pipe sign (|) followed by a file name (like schema.xsd) to the XML namespace.
 If no mapping is found for an XML namespace, a name is generated automatically (may fail).", v => namespaces.Add(v) },
                 { "o|output=", "the {FOLDER} to write the resulting .cs files to", v => outputFolder = v },
+                { "sn|splitNamespaceAndFileName", @"Whether the last segment after the '.' in the namespace will be used for output file name.
+For example, if the calculated namespace shall be: 'a.b.c', the output file will be 'c.[extension]'
+and the namespace written inside the generated file will be 'a.b'", v => splitNamespaceAndFileName = v != null },
                 { "i|integer=", @"map xs:integer and derived types to {TYPE} instead of automatic approximation
 {TYPE} can be i[nt], l[ong], or d[ecimal].", v => {
                                          switch (v)
@@ -138,6 +142,7 @@ If no mapping is found for an XML namespace, a name is generated automatically (
             {
                 NamespaceProvider = namespaceMap,
                 OutputFolder = outputFolder,
+                SplitNamespaceAndFileName = splitNamespaceAndFileName,
                 GenerateNullables = nullables,
                 EnableDataBinding = enableDataBinding,
                 EmitOrder = emitOrder,

--- a/XmlSchemaClassGenerator.Tests/xsd/vstst/vstst.xsd
+++ b/XmlSchemaClassGenerator.Tests/xsd/vstst/vstst.xsd
@@ -1422,7 +1422,7 @@
     <xs:attribute name="spoolMessage" type="xs:boolean" use="optional" default="true"/>
     <xs:attribute name="processExitCode" type="xs:int" use="optional"/>
     <xs:attribute name="isAborted" type="xs:boolean" use="optional"/>
-    <xs:attribute name="relativeTestOutputDirectory" type="xs:string" use="optional"/>
+    <xs:attribute name="relativeTest_outputDirectory" type="xs:string" use="optional"/>
   </xs:complexType>
   <xs:element name="TestRunConfiguration" type="TestRunConfiguration"/>
   <xs:complexType name="TestRunConfiguration">

--- a/XmlSchemaClassGenerator/FileOutputWriter.cs
+++ b/XmlSchemaClassGenerator/FileOutputWriter.cs
@@ -1,24 +1,30 @@
 ﻿using System.CodeDom;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 
 namespace XmlSchemaClassGenerator
 {
     public class FileOutputWriter : OutputWriter
     {
+        private readonly string _outputDirectory;
+        private readonly bool _splitNamespaceAndFileName;
         public GeneratorConfiguration Configuration { get; set; }
 
-        public FileOutputWriter(string directory, bool createIfNotExists = true)
+        public FileOutputWriter(
+            string directory, 
+            bool createIfNotExists = true,
+            bool splitNamespaceAndFileNameName = false)
         {
-            OutputDirectory = directory;
+            _splitNamespaceAndFileName = splitNamespaceAndFileNameName;
+            _outputDirectory = directory;
 
-            if (createIfNotExists && !Directory.Exists(OutputDirectory))
+            if (createIfNotExists && !Directory.Exists(_outputDirectory))
             {
-                Directory.CreateDirectory(OutputDirectory);
+                Directory.CreateDirectory(_outputDirectory);
             }
         }
 
-        public string OutputDirectory { get; }
 
         /// <summary>
         /// A list of all the files written.
@@ -30,7 +36,24 @@ namespace XmlSchemaClassGenerator
             var cu = new CodeCompileUnit();
             cu.Namespaces.Add(cn);
 
-            var path = Path.Combine(OutputDirectory, cn.Name + ".cs");
+            string fileName;
+            if (_splitNamespaceAndFileName && cn.Name.Contains('.'))
+            {
+                var namespaceSegments = cn.Name.Split('.');
+                // last segment will be used as file name:
+                fileName = namespaceSegments.Last();
+                
+                // rebuild the namespace without the last:
+                var allButLast = namespaceSegments.Take(namespaceSegments.Length - 1);
+                cn.Name = string.Join(".", allButLast);
+            }
+            else
+            {
+                fileName = cn.Name;
+            }
+      
+
+            var path = Path.Combine(_outputDirectory, fileName + ".cs");
             Configuration?.WriteLog(path);
 
             WriteFile(path, cu);

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -48,6 +48,13 @@ namespace XmlSchemaClassGenerator
             set { _configuration.OutputFolder = value; }
         }
 
+        public bool SplitNamespaceAndFileName
+        {
+            get { return _configuration.SplitNamespaceAndFileName; }
+            set { _configuration.SplitNamespaceAndFileName = value; }
+        }
+
+
         public Action<string> Log
         {
             get { return _configuration.Log; }
@@ -247,7 +254,14 @@ namespace XmlSchemaClassGenerator
 
             var m = new ModelBuilder(_configuration, set);
             var namespaces = m.GenerateCode();
-            var writer = _configuration.OutputWriter ?? new FileOutputWriter(OutputFolder ?? ".") { Configuration = _configuration };
+            var writer = _configuration.OutputWriter ??
+                         new FileOutputWriter(
+                             OutputFolder ?? ".", 
+                             true, 
+                             _configuration.SplitNamespaceAndFileName)
+                         {
+                             Configuration = _configuration
+                         };
 
             foreach (var ns in namespaces)
             {

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -44,6 +44,12 @@ namespace XmlSchemaClassGenerator
         public OutputWriter OutputWriter { get; set; }
 
         /// <summary>
+        /// Whether to split the namespace and use the last segment after the "."
+        /// to be the outpur Filename (without the file extension)
+        /// </summary>
+        public bool SplitNamespaceAndFileName { get; set; }
+
+        /// <summary>
         /// A provider to obtain the name and version of the tool
         /// </summary>
         public VersionProvider Version { get; set; }


### PR DESCRIPTION
We don't always like to generate same - filename as the namespace.
Example for my usage in msbuild csproj:
  <Target Name="GenerateSerializationClasses" BeforeTargets="BeforeBuild" Inputs="%(XSDFile.Identity)" Outputs="%(XSDFile.Identity).cs">
    <Message Importance="High" Text="Generating iVision classes...%(XSDFile.Identity)" />
    <Exec Command="XmlSchemaClassGenerator.Console.exe --sn --pascal=false --prefix=My.Real.Namespace.I.Need -n &quot;|%(XSDFile.Identity)=%(XSDFile.Filename)&quot; %(XSDFile.Identity)" />
  </Target>

each somefile.xsd
will have output file somefile.cs
and the namespace it will contain will be:
My.Real.Namespace.I.Need