### PR TITLE
Add CLR type to the dictionary key for generated TypeModels

### DIFF
--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -690,6 +690,41 @@ namespace XmlSchemaClassGenerator.Tests
         }
 
         [Fact]
+        public void CollidingElementAndComplexTypeNamesCanBeResolved()
+        {
+            const string xsd = @"<?xml version=""1.0"" encoding = ""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"" targetNamespace=""http://local.none"">
+  <xs:complexType name=""MyType"">
+    <xs:sequence>
+      <xs:element maxOccurs=""1"" minOccurs=""0"" name=""output"" type=""xs:string""/>
+    </xs:sequence>
+  </xs:complexType>
+  <xs:element name=""MyType"">
+    <xs:simpleType>
+      <xs:restriction base=""xs:string"">
+        <xs:enumeration value=""Choice1""/>
+        <xs:enumeration value=""Choice2""/>
+        <xs:enumeration value=""Choice3""/>
+      </xs:restriction>
+    </xs:simpleType>
+  </xs:element>
+</xs:schema>
+";
+            var generator = new Generator
+            {
+                NamespaceProvider = new NamespaceProvider
+                {
+                    GenerateNamespace = key => "Test"
+                }
+            };
+
+            var generatedType = ConvertXml(nameof(CollidingElementAndComplexTypeNamesCanBeResolved), xsd, generator).First();
+
+            Assert.Contains(@"public partial class MyType", generatedType);
+            Assert.Contains(@"public enum MyType", generatedType);
+        }
+
+        [Fact]
         public void ComplexTypeWithAttributeGroupExtension()
         {
             const string xsd = @"<?xml version=""1.0"" encoding=""UTF-8""?>

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -387,6 +387,7 @@ namespace XmlSchemaClassGenerator
                         Namespace = namespaceModel,
                         XmlSchemaName = qualifiedName,
                         XmlSchemaType = simpleType,
+                        IsAnonymous = string.IsNullOrEmpty(simpleType.QualifiedName.Name),
                     };
 
                     enumModel.Documentation.AddRange(docs);


### PR DESCRIPTION
I added the XML Schema element name to the dictionary key on the assumption that an `element` with the name `MyType` is distinct from a `complexType` with the name `MyType` and that both items should have a corresponding `TypeModel`. This assumption should hold for all combinations of Schema items, such as a `simpleType` and `complexType` that share a name. Because the original element name (`xs:complexType`, `xs:element`, etc.) is encoded into the CLR type name (`XmlSchemaComplexType`, `XmlSchemaElement`, etc.), I added the CLR type name to the beginning of the dictionary key.

I also included a test that verified the existence of #50 and verifies the implemented fix.