### PR TITLE
Enhance deduction of integer type

### DIFF
--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -22,6 +22,7 @@ namespace XmlSchemaClassGenerator.Console
             var namespaces = new List<string>();
             var outputFolder = (string)null;
             var integerType = typeof(string);
+            var useIntegerTypeAsFallback = false;
             var namespacePrefix = "";
             var verbose = false;
             var nullables = false;
@@ -71,6 +72,7 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                                                  break;
                                          }
                                      } },
+                { "fb|fallback|use-integer-type-as-fallback", v => useIntegerTypeAsFallback = v != null },
                 { "e|edb|enable-data-binding", "enable INotifyPropertyChanged data binding", v => enableDataBinding = v != null },
                 { "r|order", "emit order for all class members stored as XML element", v => emitOrder = v != null },
                 { "c|pcl", "PCL compatible output", v => pclCompatible = v != null },
@@ -144,6 +146,7 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 EnableDataBinding = enableDataBinding,
                 EmitOrder = emitOrder,
                 IntegerDataType = integerType,
+                UseIntegerDataTypeAsFallback = useIntegerTypeAsFallback,
                 EntityFramework = entityFramework,
                 GenerateInterfaces = interfaces,
                 NamingScheme = pascal ? NamingScheme.PascalCase : NamingScheme.Direct,

--- a/XmlSchemaClassGenerator.Tests/IntegerTypeTests.cs
+++ b/XmlSchemaClassGenerator.Tests/IntegerTypeTests.cs
@@ -1,0 +1,167 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Schema;
+using Xunit;
+
+namespace XmlSchemaClassGenerator.Tests {
+    public class IntegerTypeTests
+    {
+        private IEnumerable<string> ConvertXml(string name, string xsd, Generator generatorPrototype = null)
+        {
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            var writer = new MemoryOutputWriter();
+
+            var gen = new Generator
+            {
+                OutputWriter = writer,
+                Version = new VersionProvider("Tests", "1.0.0.1"),
+                NamespaceProvider = generatorPrototype.NamespaceProvider,
+                GenerateNullables = generatorPrototype.GenerateNullables,
+                IntegerDataType = generatorPrototype.IntegerDataType,
+                UseIntegerDataTypeAsFallback = generatorPrototype.UseIntegerDataTypeAsFallback,
+                DataAnnotationMode = generatorPrototype.DataAnnotationMode,
+                GenerateDesignerCategoryAttribute = generatorPrototype.GenerateDesignerCategoryAttribute,
+                GenerateComplexTypesForCollections = generatorPrototype.GenerateComplexTypesForCollections,
+                EntityFramework = generatorPrototype.EntityFramework,
+                AssemblyVisible = generatorPrototype.AssemblyVisible,
+                GenerateInterfaces = generatorPrototype.GenerateInterfaces,
+                MemberVisitor = generatorPrototype.MemberVisitor,
+                CodeTypeReferenceOptions = generatorPrototype.CodeTypeReferenceOptions
+            };
+
+            var set = new XmlSchemaSet();
+
+            using (var stringReader = new StringReader(xsd))
+            {
+                var schema = XmlSchema.Read(stringReader, (s, e) =>
+                {
+                  throw new InvalidOperationException($"{e.Severity}: {e.Message}",e.Exception);
+                });
+
+                set.Add(schema);
+            }
+
+            gen.Generate(set);
+
+            return writer.Content;
+        }
+
+        [Theory]
+        [InlineData(2, "sbyte")]
+        [InlineData(4, "short")]
+        [InlineData(9, "int")]
+        [InlineData(18, "long")]
+        [InlineData(28, "decimal")]
+        [InlineData(29, "string")]
+        public void TestTotalDigits(int totalDigits, string expectedType)
+        {
+            var xsd = @$"<?xml version=""1.0"" encoding=""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+	<xs:complexType name=""document"">
+    <xs:sequence>
+		  <xs:element name=""someValue"">
+			  <xs:simpleType>
+				  <xs:restriction base=""xs:integer"">
+            <xs:totalDigits value=""{totalDigits}""/>
+				  </xs:restriction>
+			  </xs:simpleType>
+		  </xs:element>
+    </xs:sequence>
+	</xs:complexType>
+</xs:schema>";
+
+            var generatedType = ConvertXml(nameof(TestTotalDigits), xsd, new Generator
+            {
+                NamespaceProvider = new NamespaceProvider
+                {
+                    GenerateNamespace = key => "Test"
+                }
+            });
+
+            var expectedProperty = $"public {expectedType} SomeValue";
+            Assert.Contains(expectedProperty, generatedType.First());
+        }
+
+        [Theory]
+        [InlineData(4, false, "long")]
+        [InlineData(30, false, "long")]
+        [InlineData(4, true, "short")]
+        [InlineData(30, true, "long")]
+        public void TestFallbackType(int totalDigits, bool useTypeAsFallback, string expectedType)
+        {
+            var xsd = @$"<?xml version=""1.0"" encoding=""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+	<xs:complexType name=""document"">
+    <xs:sequence>
+		  <xs:element name=""someValue"">
+			  <xs:simpleType>
+				  <xs:restriction base=""xs:integer"">
+            <xs:totalDigits value=""{totalDigits}""/>
+				  </xs:restriction>
+			  </xs:simpleType>
+		  </xs:element>
+    </xs:sequence>
+	</xs:complexType>
+</xs:schema>";
+
+          var generatedType = ConvertXml(nameof(TestTotalDigits), xsd, new Generator
+          {
+              NamespaceProvider = new NamespaceProvider
+              {
+                  GenerateNamespace = key => "Test"
+              },
+              IntegerDataType = typeof(long),
+              UseIntegerDataTypeAsFallback = useTypeAsFallback
+          });
+
+          var expectedProperty = $"public {expectedType} SomeValue";
+          Assert.Contains(expectedProperty, generatedType.First());
+        }
+
+        [Theory]
+        [InlineData(1, 100, "byte")]
+        [InlineData(-100, 100, "sbyte")]
+        [InlineData(1, 1000, "ushort")]
+        [InlineData(-1000, 1000, "short")]
+        [InlineData(1, 100000, "uint")]
+        [InlineData(-100000, 100000, "int")]
+        [InlineData(1, 10000000000, "ulong")]
+        [InlineData(-10000000000, 10000000000, "long")]
+        public void TestInclusiveRange(long minInclusive, long maxInclusive, string expectedType)
+        {
+            var xsd = @$"<?xml version=""1.0"" encoding=""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+	<xs:complexType name=""document"">
+    <xs:sequence>
+		  <xs:element name=""someValue"">
+			  <xs:simpleType>
+				  <xs:restriction base=""xs:integer"">
+            <xs:minInclusive value=""{minInclusive}""/>
+            <xs:maxInclusive value=""{maxInclusive}""/>
+				  </xs:restriction>
+			  </xs:simpleType>
+		  </xs:element>
+    </xs:sequence>
+	</xs:complexType>
+</xs:schema>";
+
+          var generatedType = ConvertXml(nameof(TestTotalDigits), xsd, new Generator
+          {
+              NamespaceProvider = new NamespaceProvider
+              {
+                  GenerateNamespace = key => "Test"
+              }
+          });
+
+          var expectedProperty = $"public {expectedType} SomeValue";
+          Assert.Contains(expectedProperty, generatedType.First());
+        }
+    }
+}

--- a/XmlSchemaClassGenerator/CodeUtilities.cs
+++ b/XmlSchemaClassGenerator/CodeUtilities.cs
@@ -57,7 +57,7 @@ namespace XmlSchemaClassGenerator
 
         private static Type GetIntegerDerivedType(XmlSchemaDatatype type, GeneratorConfiguration configuration, IEnumerable<RestrictionModel> restrictions)
         {
-            if (configuration.IntegerDataType != null) return configuration.IntegerDataType;
+            if (configuration.IntegerDataType != null && !configuration.UseIntegerDataTypeAsFallback) return configuration.IntegerDataType;
 
             var xmlTypeCode = type.TypeCode;
 
@@ -70,6 +70,8 @@ namespace XmlSchemaClassGenerator
                      || xmlTypeCode == XmlTypeCode.NegativeInteger
                      || xmlTypeCode == XmlTypeCode.NonPositiveInteger) && totalDigits.Value >= 29))
             {
+                if (configuration.UseIntegerDataTypeAsFallback && configuration.IntegerDataType != null)
+                  return configuration.IntegerDataType;
                 return typeof(string);
             }
 

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -156,6 +156,12 @@ namespace XmlSchemaClassGenerator
             set { _configuration.IntegerDataType = value; }
         }
 
+        public bool UseIntegerDataTypeAsFallback
+        {
+            get { return _configuration.UseIntegerDataTypeAsFallback; }
+            set { _configuration.UseIntegerDataTypeAsFallback = value; }
+        }
+
         public bool EntityFramework
         {
             get { return _configuration.EntityFramework; }

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -135,6 +135,10 @@ namespace XmlSchemaClassGenerator
         /// </summary>
         public Type IntegerDataType { get; set; }
         /// <summary>
+        /// Use <see cref="IntegerDataType"/> only if no better type can be inferred
+        /// </summary>
+        public bool UseIntegerDataTypeAsFallback { get; set; }
+        /// <summary>
         /// Generate Entity Framework Code First compatible classes
         /// </summary>
         public bool EntityFramework { get; set; }


### PR DESCRIPTION
First, support for the `minInclusive` and `maxExclusive` facets were added. If present, these restrictions will be used to find the CLR type with the smallest range that completely includes the bounds given by the schema will be chosen, with unsigned types given precedence. If not present, or if no CLR type fits the given range, the original logic using `totalDigits` will be used.

Second, a new configuration option has been added that allows users to specify a fallback data type. Previously, any consumer-specified data type would short-circuit the size deduction. Now, consumers can choose whether their type should be used in all cases, or if their type should be used only if no type can be deduced (replacing `string` as the fallback).

Fixes #185 