### PR TITLE
Added an optional TypeVisitor delegate

### DIFF
--- a/XmlSchemaClassGenerator.Tests/VisitorTests.cs
+++ b/XmlSchemaClassGenerator.Tests/VisitorTests.cs
@@ -1,0 +1,194 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml.Schema;
+using Xunit;
+
+namespace XmlSchemaClassGenerator.Tests {
+    public class VisitorTests
+    {
+        private IEnumerable<string> ConvertXml(string name, string xsd, Generator generatorPrototype = null)
+        {
+            if (name is null)
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
+            var writer = new MemoryOutputWriter();
+
+            var gen = new Generator
+            {
+                OutputWriter = writer,
+                Version = new VersionProvider("Tests", "1.0.0.1"),
+                NamespaceProvider = generatorPrototype.NamespaceProvider,
+                GenerateNullables = generatorPrototype.GenerateNullables,
+                IntegerDataType = generatorPrototype.IntegerDataType,
+                DataAnnotationMode = generatorPrototype.DataAnnotationMode,
+                GenerateDesignerCategoryAttribute = generatorPrototype.GenerateDesignerCategoryAttribute,
+                GenerateComplexTypesForCollections = generatorPrototype.GenerateComplexTypesForCollections,
+                EntityFramework = generatorPrototype.EntityFramework,
+                AssemblyVisible = generatorPrototype.AssemblyVisible,
+                GenerateInterfaces = generatorPrototype.GenerateInterfaces,
+                MemberVisitor = generatorPrototype.MemberVisitor,
+                TypeVisitor = generatorPrototype.TypeVisitor,
+                CodeTypeReferenceOptions = generatorPrototype.CodeTypeReferenceOptions
+            };
+
+            var set = new XmlSchemaSet();
+
+            using (var stringReader = new StringReader(xsd))
+            {
+                var schema = XmlSchema.Read(stringReader, (s, e) =>
+                {
+                    throw new InvalidOperationException($"{e.Severity}: {e.Message}",e.Exception);
+                });
+
+                set.Add(schema);
+            }
+
+            gen.Generate(set);
+
+            return writer.Content;
+        }
+
+        [Fact]
+        public void MemberVisitorIsCalledForProperty()
+        {
+            const string xsd = @"<?xml version=""1.0"" encoding = ""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"" targetNamespace=""http://local.none"">
+  <xs:complexType name=""MyType"">
+    <xs:sequence>
+      <xs:element maxOccurs=""1"" minOccurs=""0"" name=""output"" type=""xs:string""/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>
+";
+
+            var memberVisitorWasCalled = false;
+            var generatedType = ConvertXml(nameof(MemberVisitorIsCalledForProperty), xsd, new Generator
+            {
+                NamespaceProvider = new NamespaceProvider
+                {
+                    GenerateNamespace = key => "Test"
+                },
+                MemberVisitor = (member, model) => memberVisitorWasCalled = true
+            });
+
+            Assert.True(memberVisitorWasCalled);
+        }
+
+        [Fact]
+        public void MemberVisitorIsCalledForAllNullableProperties()
+        {
+            const string xsd = @"<?xml version=""1.0"" encoding = ""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"" targetNamespace=""http://local.none"">
+  <xs:complexType name=""MyType"">
+    <xs:sequence>
+      <xs:element maxOccurs=""1"" minOccurs=""0"" name=""output"" type=""xs:int""/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>
+";
+
+            var visitorCount = 0;
+            var generatedType = ConvertXml(nameof(MemberVisitorIsCalledForProperty), xsd, new Generator
+            {
+                NamespaceProvider = new NamespaceProvider
+                {
+                    GenerateNamespace = key => "Test"
+                },
+                GenerateNullables = true,
+                MemberVisitor = (member, model) => visitorCount++
+            });
+
+            // Visitor should be called 3 times: Value, ValueSpecified, and Nullable
+            Assert.Equal(3, visitorCount);
+        }
+
+        [Fact]
+        public void MemberVisitorIsCalledForTextContent()
+        {
+            const string xsd = @"<?xml version=""1.0"" encoding = ""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"" targetNamespace=""http://local.none"">
+  <xs:complexType name=""MyType"">
+    <xs:simpleContent>
+      <xs:extension base=""xs:string"">
+        <xs:attribute name=""myAttribute"" type=""xs:string""/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+</xs:schema>
+";
+
+            var visitorCount = 0;
+            var generatedType = ConvertXml(nameof(MemberVisitorIsCalledForProperty), xsd, new Generator
+            {
+                NamespaceProvider = new NamespaceProvider
+                {
+                    GenerateNamespace = key => "Test"
+                },
+                GenerateNullables = true,
+                MemberVisitor = (member, model) => visitorCount++
+            });
+
+            // Visitor should be called 2 times: Value and MyAttribute
+            Assert.Equal(2, visitorCount);
+        }
+
+        [Fact]
+        public void TypeVisitorIsCalledForClass()
+        {
+            const string xsd = @"<?xml version=""1.0"" encoding = ""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"" targetNamespace=""http://local.none"">
+  <xs:complexType name=""MyType"">
+    <xs:sequence>
+      <xs:element maxOccurs=""1"" minOccurs=""0"" name=""output"" type=""xs:string""/>
+    </xs:sequence>
+  </xs:complexType>
+</xs:schema>
+";
+
+            var typeVisitorWasCalled = false;
+            var generatedType = ConvertXml(nameof(MemberVisitorIsCalledForProperty), xsd, new Generator
+            {
+                NamespaceProvider = new NamespaceProvider
+                {
+                    GenerateNamespace = key => "Test"
+                },
+                TypeVisitor = (type, model) => typeVisitorWasCalled = true
+            });
+
+            Assert.True(typeVisitorWasCalled);
+        }
+
+        [Fact]
+        public void TypeVisitorIsCalledForEnum()
+        {
+            const string xsd = @"<?xml version=""1.0"" encoding = ""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"" targetNamespace=""http://local.none"">
+  <xs:simpleType name=""MyType"">
+    <xs:restriction base=""xs:string"">
+      <xs:enumeration value=""One""/>
+      <xs:enumeration value=""Two""/>
+      <xs:enumeration value=""Three""/>
+    </xs:restriction>
+  </xs:simpleType>
+</xs:schema>
+";
+
+            var typeVisitorWasCalled = false;
+            var generatedType = ConvertXml(nameof(MemberVisitorIsCalledForProperty), xsd, new Generator
+            {
+                NamespaceProvider = new NamespaceProvider
+                {
+                    GenerateNamespace = key => "Test"
+                },
+                TypeVisitor = (type, model) => typeVisitorWasCalled = true
+            });
+
+            Assert.True(typeVisitorWasCalled);
+        }
+    }
+}

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -195,6 +195,15 @@ namespace XmlSchemaClassGenerator
             set { _configuration.MemberVisitor = value; }
         }
 
+        /// <summary>
+        /// Optional delegate that is called for each generated type (class, interface, enum)
+        /// </summary>
+        public Action<CodeTypeDeclaration, TypeModel> TypeVisitor
+        {
+            get { return _configuration.TypeVisitor; }
+            set { _configuration.TypeVisitor = value; }
+        }
+
         public VersionProvider Version
         {
             get { return _configuration.Version; }

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -33,6 +33,7 @@ namespace XmlSchemaClassGenerator
             GenerateSerializableAttribute = GenerateDesignerCategoryAttribute = true;
             CollectionType = typeof(Collection<>);
             MemberVisitor = (member, model) => { };
+            TypeVisitor = (type, model) => { };
             NamingProvider = new NamingProvider(NamingScheme);
             Version = VersionProvider.CreateFromAssembly();
             EnableUpaCheck = true;
@@ -184,6 +185,11 @@ namespace XmlSchemaClassGenerator
         /// Optional delegate that is called for each generated type member
         /// </summary>
         public Action<CodeTypeMember, PropertyModel> MemberVisitor { get; set; }
+
+        /// <summary>
+        /// Optional delegate that is called for each generated type (class, interface, enum)
+        /// </summary>
+        public Action<CodeTypeDeclaration, TypeModel> TypeVisitor { get; set; }
 
         /// <summary>
         /// Provides options to customize Elementnamens with own logik

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -222,6 +222,7 @@ namespace XmlSchemaClassGenerator
 
             interfaceDeclaration.BaseTypes.AddRange(Interfaces.Select(i => i.GetReferenceFor(Namespace)).ToArray());
 
+            Configuration.TypeVisitor(interfaceDeclaration, this);
             return interfaceDeclaration;
         }
     }
@@ -473,6 +474,7 @@ namespace XmlSchemaClassGenerator
 
             classDeclaration.BaseTypes.AddRange(Interfaces.Select(i => i.GetReferenceFor(Namespace)).ToArray());
 
+            Configuration.TypeVisitor(classDeclaration, this);
             return classDeclaration;
         }
 
@@ -1249,6 +1251,7 @@ namespace XmlSchemaClassGenerator
                 enumDeclaration.Members.Add(member);
             }
 
+            Configuration.TypeVisitor(enumDeclaration, this);
             return enumDeclaration;
         }
 


### PR DESCRIPTION
I added a new delegate `TypeVisitor` that complements the existing `MemberVisitor` delegate. It allows consumers to add custom logic regarding classes, enums, and interfaces. The new delegate is called at the end of the overridden `Generate` methods, after all other processing has been completed.

Closes #183 