### PR TITLE
Implement public property setter generation for collection fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ Options:
       --cit, --collectionImplementationType=VALUE
                              the default collection type implementation to use (
                                default is null)
+      --csm, --collectionSettersMode=Private, Public, PublicWithoutConstructorInitialization
+                             generate a private, public or public setters
+                               without backing field initialization for collections
+                               (default is Private; can be: Private, Public,
+                               PublicWithoutConstructorInitialization)
       --ctro, --codeTypeReferenceOptions=GlobalReference, GenericTypeParameter
                              the default CodeTypeReferenceOptions Flags to use (
                                default is unset; can be: GlobalReference,

--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -44,6 +44,7 @@ namespace XmlSchemaClassGenerator.Console
             var generateComplexTypesForCollections = true;
             var useShouldSerialize = false;
             var separateClasses = false;
+            var collectionSettersMode = CollectionSettersMode.Private;
 
             var options = new OptionSet {
                 { "h|help", "show this message and exit", v => showHelp = v != null },
@@ -84,6 +85,30 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 { "u|enableUpaCheck", "should XmlSchemaSet check for Unique Particle Attribution (UPA) (default is enabled)", v => enableUpaCheck = v != null },
                 { "ct|collectionType=", "collection type to use (default is " + typeof(Collection<>).FullName + ")", v => collectionType = v == null ? typeof(Collection<>) : Type.GetType(v, true) },
                 { "cit|collectionImplementationType=", "the default collection type implementation to use (default is null)", v => collectionImplementationType = v == null ? null : Type.GetType(v, true) },
+                { "csm|collectionSettersMode=", @"generate a private, public or public setters 
+without backing field initialization for collections
+(default is Private; can be: {Private, Public, PublicWithoutConstructorInitialization})",
+                                        v =>
+                                        {
+                                            switch (v)
+                                            {
+                                                case "pr":
+                                                case "Private":
+                                                    collectionSettersMode = CollectionSettersMode.Private;
+                                                    break;
+                                                case "pu":
+                                                case "Public":
+                                                    collectionSettersMode = CollectionSettersMode.Public;
+                                                    break;
+                                                case "puwci":
+                                                case "PublicWithoutConstructorInitialization":
+                                                    collectionSettersMode = CollectionSettersMode.PublicWithoutConstructorInitialization;
+                                                    break;
+                                                default: 
+                                                    collectionSettersMode = CollectionSettersMode.Private;
+                                                    break;
+                                            }
+                                        }},
                 { "ctro|codeTypeReferenceOptions=", "the default CodeTypeReferenceOptions Flags to use (default is unset; can be: {GlobalReference, GenericTypeParameter})", v => codeTypeReferenceOptions = v == null ? default : (CodeTypeReferenceOptions)Enum.Parse(typeof(CodeTypeReferenceOptions), v, false) },
                 { "tvpn|textValuePropertyName=", "the name of the property that holds the text value of an element (default is Value)", v => textValuePropertyName = v },
                 { "dst|debuggerStepThrough", "generate DebuggerStepThroughAttribute (default is enabled)", v => generateDebuggerStepThroughAttribute = v != null },
@@ -159,7 +184,8 @@ If no mapping is found for an XML namespace, a name is generated automatically (
                 EnableUpaCheck = enableUpaCheck,
                 GenerateComplexTypesForCollections = generateComplexTypesForCollections,
                 UseShouldSerializePattern = useShouldSerialize,
-                SeparateClasses = separateClasses
+                SeparateClasses = separateClasses,
+                CollectionSettersMode = collectionSettersMode
             };
 
             if (pclCompatible)

--- a/XmlSchemaClassGenerator.Tests/Compiler.cs
+++ b/XmlSchemaClassGenerator.Tests/Compiler.cs
@@ -101,6 +101,7 @@ namespace XmlSchemaClassGenerator.Tests
                 MemberVisitor = generatorPrototype.MemberVisitor,
                 GenerateDescriptionAttribute = generatorPrototype.GenerateDescriptionAttribute,
                 CodeTypeReferenceOptions = generatorPrototype.CodeTypeReferenceOptions,
+                CollectionSettersMode = generatorPrototype.CollectionSettersMode,
                 TextValuePropertyName = generatorPrototype.TextValuePropertyName,
                 EmitOrder = generatorPrototype.EmitOrder,
                 SeparateClasses = generatorPrototype.SeparateClasses

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -173,7 +173,7 @@ namespace XmlSchemaClassGenerator.Tests
             Assert.NotNull(myClassType);
             var iListType = typeof(Collection<>);
             var collectionPropertyInfos = myClassType.GetProperties().Where(p => p.PropertyType.IsGenericType && iListType.IsAssignableFrom(p.PropertyType.GetGenericTypeDefinition())).OrderBy(p=>p.Name).ToList();
-            var publicCollectionPropertyInfos = collectionPropertyInfos.Where(p => p.SetMethod.IsPublic).ToList();
+            var publicCollectionPropertyInfos = collectionPropertyInfos.Where(p => p.SetMethod.IsPublic).OrderBy(p=>p.Name).ToList();
             Assert.True(collectionPropertyInfos.Count > 0);
             Assert.Equal(collectionPropertyInfos, publicCollectionPropertyInfos);
 
@@ -205,7 +205,7 @@ namespace XmlSchemaClassGenerator.Tests
             Assert.NotNull(myClassType);
             var iListType = typeof(Collection<>);
             var collectionPropertyInfos = myClassType.GetProperties().Where(p => p.PropertyType.IsGenericType && iListType.IsAssignableFrom(p.PropertyType.GetGenericTypeDefinition())).OrderBy(p=>p.Name).ToList();
-            var publicCollectionPropertyInfos = collectionPropertyInfos.Where(p => p.SetMethod.IsPublic).ToList();
+            var publicCollectionPropertyInfos = collectionPropertyInfos.Where(p => p.SetMethod.IsPublic).OrderBy(p=>p.Name).ToList();
             Assert.True(collectionPropertyInfos.Count > 0);
             Assert.Equal(collectionPropertyInfos, publicCollectionPropertyInfos);
             var myClassInstance = Activator.CreateInstance(myClassType);

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -155,7 +155,7 @@ namespace XmlSchemaClassGenerator.Tests
         [Fact]
         public void TestListWithPublicPropertySetters()
         {
-            var assembly = Compiler.Generate("List", ListPattern, new Generator {
+            var assembly = Compiler.Generate("ListPublic", ListPattern, new Generator {
                 GenerateNullables = true,
                 IntegerDataType = typeof(int),
                 DataAnnotationMode = DataAnnotationMode.All,
@@ -187,7 +187,7 @@ namespace XmlSchemaClassGenerator.Tests
         [Fact]
         public void TestListWithPublicPropertySettersWithoutConstructors()
         {
-            var assembly = Compiler.Generate("List", ListPattern, new Generator {
+            var assembly = Compiler.Generate("ListPublicWithoutConstructorInitialization", ListPattern, new Generator {
                 GenerateNullables = true,
                 IntegerDataType = typeof(int),
                 DataAnnotationMode = DataAnnotationMode.All,

--- a/XmlSchemaClassGenerator/CollectionSettersMode.cs
+++ b/XmlSchemaClassGenerator/CollectionSettersMode.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace XmlSchemaClassGenerator
+{
+    /// <summary>
+    /// Determines the kind collection accessor modifiers to emit and controls baking collection fields initialization
+    /// </summary>
+    public enum CollectionSettersMode
+    {
+        /// <summary>
+        /// All collection setters are private
+        /// </summary>
+        Private,
+        /// <summary>
+        /// All collection setters are public
+        /// </summary>
+        Public,
+        /// <summary>
+        /// All collection setters are public and baking collections fields not initialized in constructors
+        /// </summary>
+        PublicWithoutConstructorInitialization
+    }
+}

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -180,6 +180,12 @@ namespace XmlSchemaClassGenerator
             set { _configuration.CodeTypeReferenceOptions = value; }
         }
 
+        public CollectionSettersMode CollectionSettersMode
+        {
+            get { return _configuration.CollectionSettersMode; }
+            set { _configuration.CollectionSettersMode = value; }
+        }
+
         public string TextValuePropertyName
         {
             get { return _configuration.TextValuePropertyName; }

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -154,6 +154,10 @@ namespace XmlSchemaClassGenerator
         /// Generator Code reference options
         /// </summary>
         public CodeTypeReferenceOptions CodeTypeReferenceOptions { get; set; }
+        /// <summary>
+        /// Determines the kind of collection accessor modifiers to emit and controls baking collection fields initialization
+        /// </summary>
+        public CollectionSettersMode CollectionSettersMode { get; set; }
 
         /// <summary>
         /// The name of the property that will contain the text value of an XML element

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -830,7 +830,7 @@ namespace XmlSchemaClassGenerator
                 else
                     member = new CodeMemberField(typeReference, propertyName);
 
-                var isPrivateSetter = IsCollection || isArray || (IsList && IsAttribute);
+                var isPrivateSetter = (IsCollection || isArray || (IsList && IsAttribute)) && Configuration.CollectionSettersMode == CollectionSettersMode.Private;
 
                 if (requiresBackingField)
                 {
@@ -1011,7 +1011,7 @@ namespace XmlSchemaClassGenerator
             member.CustomAttributes.AddRange(attributes);
 
             // initialize List<>
-            if (IsCollection || isArray || (IsList && IsAttribute))
+            if ((IsCollection || isArray || (IsList && IsAttribute)) && Configuration.CollectionSettersMode != CollectionSettersMode.PublicWithoutConstructorInitialization)
             {
                 var constructor = typeDeclaration.Members.OfType<CodeConstructor>().FirstOrDefault();
                 if (constructor == null)


### PR DESCRIPTION
Currently only private setters generated for collection properties and this is not supported by `SGEN.exe` while it generates serialization assembly and the message is printed:

> warning CS0200: Property or indexer 'Activities.Activity' cannot be assigned to -- it is read only

This pull request introduces `collectionSettersMode` option and allows user to choose from three different options while generating code: Private, Public, PublicWithoutConstructorInitialization. Private is the default and maintains old behavior. Public generates public setters for collection properties and PublicWithoutConstructorInitialization generates public setters and skips baking field initialization in default class constructor.
