### PR TITLE
Ensure generated enum members are unique

### DIFF
--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -413,6 +413,7 @@ namespace XmlSchemaClassGenerator
                         enumModel.Values.Add(value);
                     }
 
+                    enumModel.Values = EnsureEnumValuesUnique(enumModel.Values);
                     if (namespaceModel != null)
                     {
                         namespaceModel.Types[enumModel.Name] = enumModel;
@@ -457,6 +458,23 @@ namespace XmlSchemaClassGenerator
             }
 
             return simpleModel;
+        }
+
+        private static List<EnumValueModel> EnsureEnumValuesUnique(List<EnumValueModel> enumModelValues)
+        {
+            var enumValueGroups = from enumValue in enumModelValues
+                group enumValue by enumValue.Name;
+ 
+            foreach (var g in enumValueGroups)
+            {
+                var i = 1;
+                foreach (var t in g.Skip(1))
+                {
+                    t.Name = $"{t.Name}{i++}";
+                }
+            }
+
+            return enumModelValues;
         }
 
         private IEnumerable<PropertyModel> CreatePropertiesForAttributes(Uri source, TypeModel typeModel, IEnumerable<XmlSchemaObject> items)

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -66,6 +66,26 @@ namespace XmlSchemaClassGenerator
             if (configuration.GenerateInterfaces)
             {
                 RenameInterfacePropertiesIfRenamedInDerivedClasses();
+                RemoveDuplicateInterfaceProperties();
+            }
+        }
+
+        private void RemoveDuplicateInterfaceProperties()
+        {
+            foreach (var interfaceModel in Types.Values.OfType<InterfaceModel>())
+            {
+                var parentProperties = interfaceModel.Properties.ToList();
+                foreach (var baseInterfaceType in interfaceModel.AllDerivedReferenceTypes().OfType<InterfaceModel>())
+                {
+                    foreach (var parentProperty in parentProperties)
+                    {
+                        var baseProperties = baseInterfaceType.Properties.ToList();
+                        foreach (var baseProperty in baseProperties.Where(baseProperty => parentProperty.Name == baseProperty.Name && parentProperty.Type.Name == baseProperty.Type.Name))
+                        {
+                            baseInterfaceType.Properties.Remove(baseProperty);
+                        }
+                    }
+                }
             }
         }
 

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -62,6 +62,46 @@ namespace XmlSchemaClassGenerator
                 var elements = set.GlobalElements.Values.Cast<XmlSchemaElement>().Where(s => s.GetSchema() == schema);
                 CreateElements(elements);
             }
+
+            if (configuration.GenerateInterfaces)
+            {
+                RenameInterfacePropertiesIfRenamedInDerivedClasses();
+            }
+        }
+
+        private void RenameInterfacePropertiesIfRenamedInDerivedClasses()
+        {
+            foreach (var interfaceModel in Types.Values.OfType<InterfaceModel>())
+            {
+                foreach (var interfaceProperty in interfaceModel.Properties)
+                {
+                    foreach (var implementationClass in interfaceModel.AllDerivedReferenceTypes())
+                    foreach (var implementationClassProperty in implementationClass.Properties)
+                    {
+                        if (implementationClassProperty.Name != implementationClassProperty.OriginalPropertyName
+                            && implementationClassProperty.OriginalPropertyName == interfaceProperty.Name
+                        )
+                        {
+                            RenameInterfacePropertyInBaseClasses(interfaceModel, implementationClass, interfaceProperty, implementationClassProperty.Name);
+                            interfaceProperty.Name = implementationClassProperty.Name;
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void RenameInterfacePropertyInBaseClasses(InterfaceModel interfaceModel, ReferenceTypeModel implementationClass,
+            PropertyModel interfaceProperty, string newName)
+        {
+            foreach (var interfaceModelImplementationClass in interfaceModel.AllDerivedReferenceTypes().Where(c =>
+                c != implementationClass))
+            {
+                foreach (var propertyModel in interfaceModelImplementationClass.Properties.Where(p =>
+                    p.Name == interfaceProperty.Name))
+                {
+                    propertyModel.Name = newName;
+                }
+            }
         }
 
         private void ResolveDependencies(XmlSchema schema, List<XmlSchema> dependencyOrder, HashSet<XmlSchema> seenSchemas)
@@ -217,7 +257,7 @@ namespace XmlSchemaClassGenerator
             interfaceModel.Properties.AddRange(properties);
             var interfaces = items.Select(i => i.XmlParticle).OfType<XmlSchemaGroupRef>()
                 .Select(i => (InterfaceModel)CreateTypeModel(CodeUtilities.CreateUri(i.SourceUri), Groups[i.RefName], i.RefName));
-            interfaceModel.Interfaces.AddRange(interfaces);
+            interfaceModel.AddInterfaces(interfaces);
 
             return interfaceModel;
         }
@@ -249,7 +289,7 @@ namespace XmlSchemaClassGenerator
             interfaceModel.Properties.AddRange(properties);
             var interfaces = items.OfType<XmlSchemaAttributeGroupRef>()
                 .Select(a => (InterfaceModel)CreateTypeModel(CodeUtilities.CreateUri(a.SourceUri), AttributeGroups[a.RefName], a.RefName));
-            interfaceModel.Interfaces.AddRange(interfaces);
+            interfaceModel.AddInterfaces(interfaces);
 
             return interfaceModel;
         }
@@ -307,16 +347,18 @@ namespace XmlSchemaClassGenerator
             }
             else particle = complexType.Particle ?? complexType.ContentTypeParticle;
 
-            var items = GetElements(particle, complexType);
-            var properties = CreatePropertiesForElements(source, classModel, particle, items);
-            classModel.Properties.AddRange(properties);
+            var items = GetElements(particle, complexType).ToList();
 
             if (_configuration.GenerateInterfaces)
             {
                 var interfaces = items.Select(i => i.XmlParticle).OfType<XmlSchemaGroupRef>()
-                    .Select(i => (InterfaceModel)CreateTypeModel(CodeUtilities.CreateUri(i.SourceUri), Groups[i.RefName], i.RefName));
-                classModel.Interfaces.AddRange(interfaces);
+                    .Select(i => (InterfaceModel)CreateTypeModel(CodeUtilities.CreateUri(i.SourceUri), Groups[i.RefName], i.RefName)).ToList();
+
+                classModel.AddInterfaces(interfaces);
             }
+
+            var properties = CreatePropertiesForElements(source, classModel, particle, items);
+            classModel.Properties.AddRange(properties);
 
             XmlSchemaObjectCollection attributes = null;
             if (classModel.BaseClass != null)
@@ -344,7 +386,7 @@ namespace XmlSchemaClassGenerator
                 {
                     var attributeInterfaces = attributes.OfType<XmlSchemaAttributeGroupRef>()
                         .Select(i => (InterfaceModel)CreateTypeModel(CodeUtilities.CreateUri(i.SourceUri), AttributeGroups[i.RefName], i.RefName));
-                    classModel.Interfaces.AddRange(attributeInterfaces);
+                    classModel.AddInterfaces(attributeInterfaces);
                 }
             }
 
@@ -597,6 +639,7 @@ namespace XmlSchemaClassGenerator
                     }
 
                     var propertyName = _configuration.NamingProvider.ElementNameFromQualifiedName(element.QualifiedName);
+                    var originalPropertyName = propertyName;
                     if (propertyName == typeModel.Name)
                     {
                         propertyName += "Property"; // member names cannot be the same as their enclosing type
@@ -607,6 +650,7 @@ namespace XmlSchemaClassGenerator
                         OwningType = typeModel,
                         XmlSchemaName = element.QualifiedName,
                         Name = propertyName,
+                        OriginalPropertyName = originalPropertyName,
                         Type = CreateTypeModel(source, element.ElementSchemaType, elementQualifiedName),
                         IsNillable = element.IsNillable,
                         IsNullable = item.MinOccurs < 1.0m || (item.XmlParent is XmlSchemaChoice),

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.CodeDom;
 using System.CodeDom.Compiler;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
@@ -193,17 +194,16 @@ namespace XmlSchemaClassGenerator
         }
     }
 
-    public class InterfaceModel : TypeModel
+    public class InterfaceModel : ReferenceTypeModel
     {
         public InterfaceModel(GeneratorConfiguration configuration)
             : base(configuration)
         {
             Properties = new List<PropertyModel>();
-            Interfaces = new List<InterfaceModel>();
+            DerivedTypes = new List<ReferenceTypeModel>();
         }
 
-        public List<PropertyModel> Properties { get; set; }
-        public List<InterfaceModel> Interfaces { get; set; }
+        public List<ReferenceTypeModel> DerivedTypes { get; set; }
 
         public override CodeTypeDeclaration Generate()
         {
@@ -224,23 +224,48 @@ namespace XmlSchemaClassGenerator
 
             return interfaceDeclaration;
         }
+
+        public IEnumerable<ReferenceTypeModel> AllDerivedReferenceTypes()
+        {
+            foreach (var interfaceModelDerivedType in DerivedTypes)
+            {
+                yield return interfaceModelDerivedType;
+                switch (interfaceModelDerivedType)
+                {
+                    case InterfaceModel derivedInterfaceModel:
+                    {
+                        foreach (var referenceTypeModel in derivedInterfaceModel.AllDerivedReferenceTypes())
+                        {
+                            yield return referenceTypeModel;
+                        }
+
+                        break;
+                    }
+                    case ClassModel derivedClassModel:
+                    {
+                        foreach (var baseClass in derivedClassModel.GetAllDerivedTypes())
+                        {
+                            yield return baseClass;
+                        }
+
+                        break;
+                    }
+                }
+            }
+        }
     }
 
-    public class ClassModel : TypeModel
+    public class ClassModel : ReferenceTypeModel
     {
         public bool IsAbstract { get; set; }
         public bool IsMixed { get; set; }
         public bool IsSubstitution { get; set; }
         public XmlQualifiedName SubstitutionName { get; set; }
         public TypeModel BaseClass { get; set; }
-        public List<PropertyModel> Properties { get; set; }
-        public List<InterfaceModel> Interfaces { get; set; }
         public List<ClassModel> DerivedTypes { get; set; }
         public ClassModel(GeneratorConfiguration configuration)
             : base(configuration)
         {
-            Properties = new List<PropertyModel>();
-            Interfaces = new List<InterfaceModel>();
             DerivedTypes = new List<ClassModel>();
         }
 
@@ -514,11 +539,35 @@ namespace XmlSchemaClassGenerator
         }
     }
 
+    public class ReferenceTypeModel : TypeModel
+    {
+        public ReferenceTypeModel(GeneratorConfiguration configuration)
+            : base(configuration)
+        {
+            Properties = new List<PropertyModel>();
+            Interfaces = new List<InterfaceModel>();
+        }
+
+        public List<PropertyModel> Properties { get; set; }
+        public List<InterfaceModel> Interfaces { get; }
+        
+        public void AddInterfaces(IEnumerable<InterfaceModel> interfaces)
+        {
+            foreach (var interfaceModel in interfaces)
+            {
+                Interfaces.Add(interfaceModel);
+                interfaceModel.DerivedTypes.Add(this);
+            }
+            
+        }
+    }
+
     [DebuggerDisplay("{Name}")]
     public class PropertyModel
     {
         public TypeModel OwningType { get; set; }
         public string Name { get; set; }
+        public string OriginalPropertyName { get; set; }
         public bool IsAttribute { get; set; }
         public TypeModel Type { get; set; }
         public bool IsNullable { get; set; }


### PR DESCRIPTION
It is valid to have an XSD enumeration with values that differs only in character case. E.g. one can use enum value 'M' for month definition and another value 'm' for minutes. To ensure that enum members are unique in generated code after name generation this commit adds positive integer postfix for each non unique enum member name: A A1 BB BB1 BB2 generated for input enum values a A bb bB BB