### PR TITLE
Fix CodeUtilities.QualifiedName for anonymous types

### DIFF
--- a/XmlSchemaClassGenerator/CodeUtilities.cs
+++ b/XmlSchemaClassGenerator/CodeUtilities.cs
@@ -250,7 +250,14 @@ namespace XmlSchemaClassGenerator
             XmlQualifiedName qualifiedName;
             if (!(typeModel is SimpleModel simpleTypeModel))
             {
-                qualifiedName = typeModel.XmlSchemaType.GetQualifiedName();
+                if (typeModel.IsAnonymous)
+                {
+                    qualifiedName = typeModel.XmlSchemaName;
+                }
+                else
+                {
+                    qualifiedName = typeModel.XmlSchemaType.GetQualifiedName();
+                }
             }
             else
             {


### PR DESCRIPTION
For anonymous simple type CodeUtilities.GetQualifiedName returns base type name (e.g. string) and for complex types 'anyType'.

In this commit CodeUtilities.GetQualifiedName returns an element QualifiedName.