### PR TITLE
Check for null in *Specified properties

### DIFF
--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -1058,6 +1058,11 @@ namespace XmlSchemaClassGenerator
                 var listReference = new CodePropertyReferenceExpression(new CodeThisReferenceExpression(), Name);
                 var countReference = new CodePropertyReferenceExpression(listReference, "Count");
                 var notZeroExpression = new CodeBinaryOperatorExpression(countReference, CodeBinaryOperatorType.IdentityInequality, new CodePrimitiveExpression(0));
+                if (Configuration.CollectionSettersMode == CollectionSettersMode.PublicWithoutConstructorInitialization)
+                {
+                    var notNullExpression = new CodeBinaryOperatorExpression(listReference, CodeBinaryOperatorType.IdentityInequality, new CodePrimitiveExpression(null));
+                    notZeroExpression = new CodeBinaryOperatorExpression(notNullExpression, CodeBinaryOperatorType.BooleanAnd, notZeroExpression);
+                }
                 var returnStatement = new CodeMethodReturnStatement(notZeroExpression);
                 specifiedProperty.GetStatements.Add(returnStatement);
 


### PR DESCRIPTION
 Check for null in *Specified properties when collection not initialized in constructor

If CollectionSettersMode.PublicWithoutConstructorInitialization is set for generator then in special properties with *Specified postfix we must check if backing collection field is null to defend user from NullReferenceException.