### PR TITLE
Support for omitting IsNullable=true generation for nullable elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,11 @@ Options:
                                pattern (default is false)
       --sf, --separateFiles  generate a separate file for each class (default
                                is false)
+      --dnfin, --noNotForceIsNullable
+                             do not force generator to emit IsNullable = true
+                               in XmlElement annotation for nillable elements
+                               when element is nullable (minOccurs < 1 or
+                               parent element is choice) (default is false)
 ```
 
 For use from code use the [library NuGet package](https://www.nuget.org/packages/XmlSchemaClassGenerator-beta/):

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Options:
                                pattern (default is false)
       --sf, --separateFiles  generate a separate file for each class (default
                                is false)
-      --dnfin, --noNotForceIsNullable
+      --dnfin, --doNotForceIsNullable
                              do not force generator to emit IsNullable = true
                                in XmlElement annotation for nillable elements
                                when element is nullable (minOccurs < 1 or

--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -46,6 +46,7 @@ namespace XmlSchemaClassGenerator.Console
             var useShouldSerialize = false;
             var separateClasses = false;
             var collectionSettersMode = CollectionSettersMode.Private;
+            var doNotForceIsNullable = false;
 
             var options = new OptionSet {
                 { "h|help", "show this message and exit", v => showHelp = v != null },
@@ -120,6 +121,7 @@ without backing field initialization for collections
                 { "cc|complexTypesForCollections", "generate complex types for collections (default is true)", v => generateComplexTypesForCollections = v != null },
                 { "s|useShouldSerialize", "use ShouldSerialize pattern instead of Specified pattern (default is false)", v => useShouldSerialize = v != null },
                 { "sf|separateFiles", "generate a separate file for each class (default is false)", v => separateClasses = v != null },
+                { "dnfin|noNotForceIsNullable", "do not force generator to emit IsNullable = true in XmlElement annotation for nillable elements when element is nullable (minOccurs < 1 or parent element is choice) (default is false)", v => doNotForceIsNullable = v != null }
             };
 
             var globsAndUris = options.Parse(args);
@@ -188,7 +190,8 @@ without backing field initialization for collections
                 GenerateComplexTypesForCollections = generateComplexTypesForCollections,
                 UseShouldSerializePattern = useShouldSerialize,
                 SeparateClasses = separateClasses,
-                CollectionSettersMode = collectionSettersMode
+                CollectionSettersMode = collectionSettersMode,
+                DoNotForceIsNullable = doNotForceIsNullable
             };
 
             if (pclCompatible)

--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -121,7 +121,7 @@ without backing field initialization for collections
                 { "cc|complexTypesForCollections", "generate complex types for collections (default is true)", v => generateComplexTypesForCollections = v != null },
                 { "s|useShouldSerialize", "use ShouldSerialize pattern instead of Specified pattern (default is false)", v => useShouldSerialize = v != null },
                 { "sf|separateFiles", "generate a separate file for each class (default is false)", v => separateClasses = v != null },
-                { "dnfin|noNotForceIsNullable", "do not force generator to emit IsNullable = true in XmlElement annotation for nillable elements when element is nullable (minOccurs < 1 or parent element is choice) (default is false)", v => doNotForceIsNullable = v != null }
+                { "dnfin|doNotForceIsNullable", "do not force generator to emit IsNullable = true in XmlElement annotation for nillable elements when element is nullable (minOccurs < 1 or parent element is choice) (default is false)", v => doNotForceIsNullable = v != null }
             };
 
             var globsAndUris = options.Parse(args);

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -1942,7 +1942,7 @@ namespace Test
             };
 
             var contents = ConvertXml(nameof(TestShouldPatternForCollections), xsd, generator).ToArray();
-            Assert.Equal(1, contents.Length);
+            Assert.Single(contents);
             var assembly = Compiler.Compile(nameof(TestShouldPatternForCollections), contents);
             var testType = assembly.GetType("Test_NS1.TestType");
             var serializer = new XmlSerializer(testType);
@@ -1977,7 +1977,7 @@ namespace Test
             };
 
             var contents = ConvertXml(nameof(TestDoNotForceIsNullableGeneration), xsd, generator).ToArray();
-            Assert.Equal(1, contents.Length);
+            Assert.Single(contents);
             var assembly = Compiler.Compile(nameof(TestDoNotForceIsNullableGeneration), contents);
             var testType = assembly.GetType("Test_NS1.TestType");
             var serializer = new XmlSerializer(testType);
@@ -2026,7 +2026,7 @@ namespace Test
             };
 
             var contents = ConvertXml(nameof(TestForceIsNullableGeneration), xsd, generator).ToArray();
-            Assert.Equal(1, contents.Length);
+            Assert.Single(contents);
             var assembly = Compiler.Compile(nameof(TestForceIsNullableGeneration), contents);
             var testType = assembly.GetType("Test_NS1.TestType");
             var serializer = new XmlSerializer(testType);

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -53,7 +53,8 @@ namespace XmlSchemaClassGenerator.Tests
                 AssemblyVisible = generatorPrototype.AssemblyVisible,
                 GenerateInterfaces = generatorPrototype.GenerateInterfaces,
                 MemberVisitor = generatorPrototype.MemberVisitor,
-                CodeTypeReferenceOptions = generatorPrototype.CodeTypeReferenceOptions
+                CodeTypeReferenceOptions = generatorPrototype.CodeTypeReferenceOptions,
+                DoNotForceIsNullable = generatorPrototype.DoNotForceIsNullable
             };
 
             var set = new XmlSchemaSet();
@@ -1946,6 +1947,105 @@ namespace Test
             var testType = assembly.GetType("Test_NS1.TestType");
             var serializer = new XmlSerializer(testType);
             Assert.NotNull(serializer);
+        }
+
+
+        [Fact]
+        public void TestDoNotForceIsNullableGeneration()
+        {
+            const string xsd = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <xs:schema xmlns:xs=""http://www.w3.org/2001/XMLSchema"" targetNamespace=""Test_NS1""
+            elementFormDefault=""qualified"" attributeFormDefault=""unqualified"">
+            <xs:element name=""TestType"">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name=""StringProperty"" type=""xs:string"" nillable=""true"" minOccurs=""0""/>
+						<xs:element name=""StringNullableProperty"" type=""xs:string"" nillable=""true""/>
+						<xs:element name=""StringNullableProperty2"" type=""xs:string"" nillable=""true"" minOccurs=""1""/>
+					</xs:sequence>
+				</xs:complexType>
+            </xs:element>
+            </xs:schema>";
+
+            var generator = new Generator
+            {
+                NamespaceProvider = new NamespaceProvider
+                {
+                    GenerateNamespace = key => key.XmlSchemaNamespace
+                },
+                DoNotForceIsNullable = true
+            };
+
+            var contents = ConvertXml(nameof(TestDoNotForceIsNullableGeneration), xsd, generator).ToArray();
+            Assert.Equal(1, contents.Length);
+            var assembly = Compiler.Compile(nameof(TestDoNotForceIsNullableGeneration), contents);
+            var testType = assembly.GetType("Test_NS1.TestType");
+            var serializer = new XmlSerializer(testType);
+            Assert.NotNull(serializer);
+
+            var prop = testType.GetProperty("StringProperty");
+            Assert.NotNull(prop);
+            var xmlElementAttribute = prop.GetCustomAttribute<XmlElementAttribute>();
+            Assert.False(xmlElementAttribute.IsNullable);
+
+            prop = testType.GetProperty("StringNullableProperty");
+            Assert.NotNull(prop);
+            var xmlElementNullableAttribute = prop.GetCustomAttribute<XmlElementAttribute>();
+            Assert.True(xmlElementNullableAttribute.IsNullable);
+
+            prop = testType.GetProperty("StringNullableProperty2");
+            Assert.NotNull(prop);
+            var xmlElementNullableAttribute2 = prop.GetCustomAttribute<XmlElementAttribute>();
+            Assert.True(xmlElementNullableAttribute2.IsNullable);
+        }
+
+        [Fact]
+        public void TestForceIsNullableGeneration()
+        {
+            const string xsd = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+            <xs:schema xmlns:xs=""http://www.w3.org/2001/XMLSchema"" targetNamespace=""Test_NS1""
+            elementFormDefault=""qualified"" attributeFormDefault=""unqualified"">
+            <xs:element name=""TestType"">
+				<xs:complexType>
+					<xs:sequence>
+						<xs:element name=""StringProperty"" type=""xs:string"" nillable=""true"" minOccurs=""0""/>
+						<xs:element name=""StringNullableProperty"" type=""xs:string"" nillable=""true""/>
+						<xs:element name=""StringNullableProperty2"" type=""xs:string"" nillable=""true"" minOccurs=""1""/>
+					</xs:sequence>
+				</xs:complexType>
+            </xs:element>
+            </xs:schema>";
+
+            var generator = new Generator
+            {
+                NamespaceProvider = new NamespaceProvider
+                {
+                    GenerateNamespace = key => key.XmlSchemaNamespace
+                },
+                DoNotForceIsNullable = false
+            };
+
+            var contents = ConvertXml(nameof(TestForceIsNullableGeneration), xsd, generator).ToArray();
+            Assert.Equal(1, contents.Length);
+            var assembly = Compiler.Compile(nameof(TestForceIsNullableGeneration), contents);
+            var testType = assembly.GetType("Test_NS1.TestType");
+            var serializer = new XmlSerializer(testType);
+            Assert.NotNull(serializer);
+
+            var prop = testType.GetProperty("StringProperty");
+            Assert.NotNull(prop);
+            var xmlElementAttribute = prop.GetCustomAttribute<XmlElementAttribute>();
+            Assert.True(xmlElementAttribute.IsNullable);
+
+            prop = testType.GetProperty("StringNullableProperty");
+            Assert.NotNull(prop);
+            var xmlElementNullableAttribute = prop.GetCustomAttribute<XmlElementAttribute>();
+            Assert.True(xmlElementNullableAttribute.IsNullable);
+
+            prop = testType.GetProperty("StringNullableProperty2");
+            Assert.NotNull(prop);
+            var xmlElementNullableAttribute2 = prop.GetCustomAttribute<XmlElementAttribute>();
+            Assert.True(xmlElementNullableAttribute2.IsNullable);
         }
     }
 }

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -1943,7 +1943,7 @@ namespace Test
 
             var contents = ConvertXml(nameof(TestShouldPatternForCollections), xsd, generator).ToArray();
             Assert.Equal(1, contents.Length);
-            var assembly = Compiler.Compile(nameof(GenerateXmlRootAttributeForEnumTest), contents);
+            var assembly = Compiler.Compile(nameof(TestShouldPatternForCollections), contents);
             var testType = assembly.GetType("Test_NS1.TestType");
             var serializer = new XmlSerializer(testType);
             Assert.NotNull(serializer);

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -228,6 +228,12 @@ namespace XmlSchemaClassGenerator
             set { _configuration.DisableComments = value; }
         }
 
+        public bool DoNotForceIsNullable
+        {
+            get { return _configuration.DoNotForceIsNullable; }
+            set { _configuration.DoNotForceIsNullable = value; }
+        }
+
         public string PrivateMemberPrefix
         {
             get { return _configuration.PrivateMemberPrefix; }

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -206,6 +206,12 @@ namespace XmlSchemaClassGenerator
 
         public bool DisableComments { get; set; }
 
+        /// <summary>
+        /// If True then do not force generator to emit IsNullable=true in XmlElement annotation
+        /// for nillable elements when element is nullable (minOccurs &lt; 1 or parent element is choice)
+        /// </summary>
+        public bool DoNotForceIsNullable { get; set; }
+
         public string PrivateMemberPrefix { get; set; } = "_";
 
         /// <summary>

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -1226,7 +1226,7 @@ namespace XmlSchemaClassGenerator
                     }
                 }
 
-                if (IsNillable && !(IsCollection && Type is SimpleModel m && m.ValueType.IsValueType))
+                if (IsNillable && !(IsCollection && Type is SimpleModel m && m.ValueType.IsValueType) && !(IsNullable && Configuration.DoNotForceIsNullable))
                 {
                     attribute.Arguments.Add(new CodeAttributeArgument("IsNullable", new CodePrimitiveExpression(true)));
                 }


### PR DESCRIPTION
XmlElementAttribute.IsNullable=true forces XmlSerializer to generate empty xml elements with xs:nil=true, but elements with minOccurs < 1 can be omitted entirely.

Allow users to specify option `DoNotForceIsNullable` to skip IsNullable=true generation in XmlElement attributes for nillable elements that at the same time is nullable (minOccurs < 1 or parent element is choice).