### PR TITLE
Namespaces: throw ArgumentException on invalid --namespace

### DIFF
--- a/XmlSchemaClassGenerator/CodeUtilities.cs
+++ b/XmlSchemaClassGenerator/CodeUtilities.cs
@@ -365,6 +365,11 @@ namespace XmlSchemaClassGenerator
         public static KeyValuePair<NamespaceKey, string> ParseNamespace(string nsArg, string namespacePrefix)
         {
             var parts = nsArg.Split(new[] { '=' }, 2);
+            if (parts.Length != 2)
+            {
+                throw new ArgumentException("XML and C# namespaces should be separated by '='.");
+            }
+            
             var xmlNs = parts[0];
             var netNs = parts[1];
             var parts2 = xmlNs.Split(new[] { '|' }, 2);


### PR DESCRIPTION
It's not obvious when something wrong with my `--namespace` parameter, it throws: 
```
Unhandled exception. System.IndexOutOfRangeException: Index was outside the bounds of the array.
```

So new check with ArgumentException was added.