### PR TITLE
Make global tool usable with .NET 5.0 SDK

### DIFF
--- a/xscgen-proj/xscgen-proj.csproj
+++ b/xscgen-proj/xscgen-proj.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <Description>A .NET Core CLI tool to generate XmlSerializer compatible C# classes from XML Schema files.</Description>
     <Copyright>Copyright 2013-$([System.DateTime]::Now.Year) Michael Ganss</Copyright>
     <AssemblyTitle>xscgen</AssemblyTitle>

--- a/xscgen/xscgen.csproj
+++ b/xscgen/xscgen.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netcoreapp2.1</TargetFrameworks>
     <Description>A .NET Core CLI tool to generate XmlSerializer compatible C# classes from XML Schema files.</Description>
     <Copyright>Copyright 2013-$([System.DateTime]::Now.Year) Michael Ganss</Copyright>
     <AssemblyTitle>xscgen</AssemblyTitle>


### PR DESCRIPTION
When using the dotnet local tool on a system with only .NET 5.0 SDK installed, the tool fails with this message:

```
It was not possible to find any compatible framework version
  The framework 'Microsoft.NETCore.App', version '3.1.0' was not found.
    - The following frameworks were found:
        5.0.0 at [/opt/hostedtoolcache/dotnet/shared/Microsoft.NETCore.App]
  
  You can resolve the problem by installing the specified framework and/or SDK.
  
  The specified framework can be found at:
    - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=3.1.0&arch=x64&rid=ubuntu.20.04-x64
```

This PR adds the `net5.0` TFM to the global tool project files.