### PR TITLE
Fix the `ComplexTypeWithAttributeGroupExtension` test on Linux and macOS

### DIFF
--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -1410,7 +1410,7 @@ namespace Test
 
         private static void CompareOutput(string expected, string actual)
         {
-            static string Normalize(string input) => Regex.Replace(input, @"[ \t]*\r\n", "\n");
+            static string Normalize(string input) => Regex.Replace(input, @"[ \t]*\r?\n", "\n");
             Assert.Equal(Normalize(expected), Normalize(actual));
         }
 


### PR DESCRIPTION
On Linux and macOS, the generator writes with LF (instead of CRLF) so the normalization Regex was not matching `\r\n`.