### PR TITLE
Improve collection assertions

### DIFF
--- a/XmlSchemaClassGenerator.Tests/Compiler.cs
+++ b/XmlSchemaClassGenerator.Tests/Compiler.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.Emit;
 using System;
@@ -149,11 +149,9 @@ namespace XmlSchemaClassGenerator.Tests
                 .WithOptions(new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
             var result = Compiler.GenerateAssembly(compilation);
 
+            Assert.Empty(result.Result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error));
+            Assert.Empty(result.Result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Warning));
             Assert.True(result.Result.Success);
-            var errors = result.Result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Error).ToList();
-            Assert.False(errors.Any(), string.Join("\n", errors.Select(e => e.GetMessage())));
-            var warnings = result.Result.Diagnostics.Where(d => d.Severity == DiagnosticSeverity.Warning).ToList();
-            Assert.False(warnings.Any(), string.Join("\n", errors.Select(w => w.GetMessage())));
             Assert.NotNull(result.Assembly);
 
             Assemblies[name] = result.Assembly;

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.CodeDom;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
@@ -157,7 +157,7 @@ namespace XmlSchemaClassGenerator.Tests
             var iListType = typeof(Collection<>);
             var collectionPropertyInfos = myClassType.GetProperties().Where(p => p.PropertyType.IsGenericType && iListType.IsAssignableFrom(p.PropertyType.GetGenericTypeDefinition())).OrderBy(p=>p.Name).ToList();
             var publicCollectionPropertyInfos = collectionPropertyInfos.Where(p => p.SetMethod.IsPrivate).OrderBy(p=>p.Name).ToList();
-            Assert.True(collectionPropertyInfos.Count > 0);
+            Assert.NotEmpty(collectionPropertyInfos);
             Assert.Equal(collectionPropertyInfos, publicCollectionPropertyInfos);
 
             var myClassInstance = Activator.CreateInstance(myClassType);
@@ -189,7 +189,7 @@ namespace XmlSchemaClassGenerator.Tests
             var iListType = typeof(Collection<>);
             var collectionPropertyInfos = myClassType.GetProperties().Where(p => p.PropertyType.IsGenericType && iListType.IsAssignableFrom(p.PropertyType.GetGenericTypeDefinition())).OrderBy(p=>p.Name).ToList();
             var publicCollectionPropertyInfos = collectionPropertyInfos.Where(p => p.SetMethod.IsPublic).OrderBy(p=>p.Name).ToList();
-            Assert.True(collectionPropertyInfos.Count > 0);
+            Assert.NotEmpty(collectionPropertyInfos);
             Assert.Equal(collectionPropertyInfos, publicCollectionPropertyInfos);
 
             var myClassInstance = Activator.CreateInstance(myClassType);
@@ -221,7 +221,7 @@ namespace XmlSchemaClassGenerator.Tests
             var iListType = typeof(Collection<>);
             var collectionPropertyInfos = myClassType.GetProperties().Where(p => p.PropertyType.IsGenericType && iListType.IsAssignableFrom(p.PropertyType.GetGenericTypeDefinition())).OrderBy(p=>p.Name).ToList();
             var publicCollectionPropertyInfos = collectionPropertyInfos.Where(p => p.SetMethod.IsPublic).OrderBy(p=>p.Name).ToList();
-            Assert.True(collectionPropertyInfos.Count > 0);
+            Assert.NotEmpty(collectionPropertyInfos);
             Assert.Equal(collectionPropertyInfos, publicCollectionPropertyInfos);
             var myClassInstance = Activator.CreateInstance(myClassType);
             foreach (var collectionPropertyInfo in publicCollectionPropertyInfos)
@@ -253,7 +253,7 @@ namespace XmlSchemaClassGenerator.Tests
             var iListType = typeof(Collection<>);
             var collectionPropertyInfos = myClassType.GetProperties().Where(p => p.PropertyType.IsGenericType && iListType.IsAssignableFrom(p.PropertyType.GetGenericTypeDefinition())).OrderBy(p => p.Name).ToList();
             var publicCollectionPropertyInfos = collectionPropertyInfos.Where(p => p.SetMethod.IsPublic).OrderBy(p => p.Name).ToList();
-            Assert.True(collectionPropertyInfos.Count > 0);
+            Assert.NotEmpty(collectionPropertyInfos);
             Assert.Equal(collectionPropertyInfos, publicCollectionPropertyInfos);
             var myClassInstance = Activator.CreateInstance(myClassType);
 


### PR DESCRIPTION
Asserting with Assert.Empty / Assert.NotEmpty gives much better error messages when the assertion fails.

Before:

```
Assert.True() Failure
Expected: True
Actual:   False
   at XmlSchemaClassGenerator.Tests.Compiler.Compile(String name, String[] contents) in XmlSchemaClassGenerator/XmlSchemaClassGenerator.Tests/Compiler.cs:line 152
```

After:

```
Assert.Empty() Failure
Collection: [(11144,6): error CS0579: Duplicate 'System.CodeDom.Compiler.GeneratedCodeAttribute' attribute, (11145,6): error CS0579: Duplicate 'System.SerializableAttribute' attribute, (11147,6): error CS0579: Duplicate 'System.Xml.Serialization.XmlRootAttribute' attribute, (10023,26): error CS0146: Circular base class dependency involving 'User' and 'User']
   at XmlSchemaClassGenerator.Tests.Compiler.Compile(String name, String[] contents) in XmlSchemaClassGenerator/XmlSchemaClassGenerator.Tests/Compiler.cs:line 152
```