### PR TITLE
Order files by their path

### DIFF
--- a/XmlSchemaClassGenerator.Tests/Compiler.cs
+++ b/XmlSchemaClassGenerator.Tests/Compiler.cs
@@ -62,7 +62,7 @@ namespace XmlSchemaClassGenerator.Tests
         {
             if (Assemblies.ContainsKey(name)) { return Assemblies[name]; }
 
-            var files = Glob.ExpandNames(pattern);
+            var files = Glob.ExpandNames(pattern).OrderBy(f => f);
 
             return GenerateFiles(name, files, generatorPrototype);
         }


### PR DESCRIPTION
On macOS (unlike on Windows), `Glob.ExpandNames` does not sort the files by their path. For some reason that I have not investigated, some tests related to _IS24_ fail when the files are not generated in the expected order.

In order to reproduce this issue, one can change the introduced `OrderBy` with `OrderByDescending`.