### PR TITLE
any attribute is not rendered if complex type extends other complex type

### DIFF
--- a/XmlSchemaClassGenerator.Tests/Compiler.cs
+++ b/XmlSchemaClassGenerator.Tests/Compiler.cs
@@ -112,7 +112,8 @@ namespace XmlSchemaClassGenerator.Tests
                 CompactTypeNames = generatorPrototype.CompactTypeNames,
                 UniqueTypeNamesAcrossNamespaces = generatorPrototype.UniqueTypeNamesAcrossNamespaces,
                 CreateGeneratedCodeAttributeVersion = generatorPrototype.CreateGeneratedCodeAttributeVersion,
-                NetCoreSpecificCode = generatorPrototype.NetCoreSpecificCode
+                NetCoreSpecificCode = generatorPrototype.NetCoreSpecificCode,
+                NamingScheme = generatorPrototype.NamingScheme
             };
 
             gen.CommentLanguages.Clear();

--- a/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
+++ b/XmlSchemaClassGenerator.Tests/XmlSchemaClassGenerator.Tests.csproj
@@ -24,7 +24,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Glob.cs" Version="5.1.766" />
-    <PackageReference Include="Microsoft.Net.Compilers.netcore" Version="1.3.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.11.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="System.CodeDom" Version="5.0.0" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="5.0.0" />

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -300,12 +300,24 @@ namespace XmlSchemaClassGenerator.Tests
             }
         }
 
+        public static IEnumerable<object[]> TestSimpleData() {
+            foreach (var referenceMode in new[]
+                { CodeTypeReferenceOptions.GlobalReference, /*CodeTypeReferenceOptions.GenericTypeParameter*/ })
+            foreach (var namingScheme in new[] { NamingScheme.Direct, NamingScheme.PascalCase })
+            foreach (var collectionType in new[] { typeof(Collection<>), /*typeof(Array)*/ })
+            {
+                yield return new object[] { referenceMode, namingScheme, collectionType };
+            }
+        }
 
-        [Fact, TestPriority(1)]
+
+        [Theory, TestPriority(1)]
+        [MemberData(nameof(TestSimpleData))]
         [UseCulture("en-US")]
-        public void TestSimple()
+        public void TestSimple(CodeTypeReferenceOptions referenceMode, NamingScheme namingScheme, Type collectionType)
         {
-            Compiler.Generate("Simple", SimplePattern, new Generator
+            var name = $"Simple_{referenceMode}_{namingScheme}_{collectionType}";
+            Compiler.Generate(name, SimplePattern, new Generator
             {
                 GenerateNullables = true,
                 IntegerDataType = typeof(int),
@@ -316,10 +328,13 @@ namespace XmlSchemaClassGenerator.Tests
                 GenerateInterfaces = true,
                 NamespacePrefix = "Simple",
                 GenerateDescriptionAttribute = true,
-                CodeTypeReferenceOptions = CodeTypeReferenceOptions.GlobalReference,
-                NetCoreSpecificCode = true
+                CodeTypeReferenceOptions = referenceMode,
+                NetCoreSpecificCode = true,
+                NamingScheme = namingScheme,
+                CollectionType = collectionType,
+                CollectionSettersMode = CollectionSettersMode.Public
             });
-            TestSamples("Simple", SimplePattern);
+            TestSamples(name, SimplePattern);
         }
 
         [Fact, TestPriority(1)]

--- a/XmlSchemaClassGenerator.Tests/xsd/simple/any.xsd
+++ b/XmlSchemaClassGenerator.Tests/xsd/simple/any.xsd
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema id="default"
+    targetNamespace="http://tempuri.org/default.xsd"
+    elementFormDefault="qualified"
+    xmlns="http://tempuri.org/default.xsd"
+    xmlns:mstns="http://tempuri.org/default.xsd"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+>
+  <xs:complexType name="AnyTest_ExtendedString">
+    <xs:simpleContent>
+      <xs:extension base="xs:string">
+         <xs:anyAttribute namespace="##any" processContents="lax"/>
+      </xs:extension>
+    </xs:simpleContent>
+  </xs:complexType>
+  
+  <xs:complexType name="AnyTest_Type">
+    <xs:sequence/>
+    <xs:anyAttribute namespace="##any" processContents="lax"/>
+  </xs:complexType>
+  
+  <xs:complexType name="AnyTest_ExtendedTypeWithAnyAttr">
+    <xs:complexContent>
+      <xs:extension base="AnyTest_Type">
+        <xs:anyAttribute namespace="##any" processContents="lax"/>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  
+  <xs:complexType name="AnyTest_ExtendedTypeWithoutAnyAttr">
+    <xs:complexContent>
+      <xs:extension base="AnyTest_Type" />
+    </xs:complexContent>
+  </xs:complexType>    
+  
+</xs:schema>

--- a/XmlSchemaClassGenerator.Tests/xsd/simple/fields_ambiguity.xsd
+++ b/XmlSchemaClassGenerator.Tests/xsd/simple/fields_ambiguity.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema id="default"
+    targetNamespace="http://tempuri.org/default.xsd"
+    elementFormDefault="qualified"
+    xmlns="http://tempuri.org/default.xsd"
+    xmlns:mstns="http://tempuri.org/default.xsd"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+>
+  <xs:complexType name="AmbiguityTest_Type">
+    <xs:sequence>
+      <xs:choice minOccurs="0" maxOccurs="unbounded">
+        <xs:element name="Property">
+          <xs:complexType>
+            <xs:sequence>
+              <xs:element name="Value" type="AmbiguityTest_NestedType" minOccurs="0" maxOccurs="unbounded" />
+            </xs:sequence>
+            <xs:attribute name="value" type="xs:string" use="optional" default="" />
+          </xs:complexType>
+        </xs:element>
+      </xs:choice>
+    </xs:sequence>
+  </xs:complexType>
+
+  <xs:complexType name="AmbiguityTest_NestedType">
+    <xs:attribute name="NestedItem" type="xs:string" use="required" />
+  </xs:complexType>	
+
+</xs:schema>

--- a/XmlSchemaClassGenerator.Tests/xsd/simple/nested_type.xsd
+++ b/XmlSchemaClassGenerator.Tests/xsd/simple/nested_type.xsd
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+
+<xs:schema id="default"
+    targetNamespace="http://tempuri.org/default.xsd"
+    elementFormDefault="qualified"
+    xmlns="http://tempuri.org/default.xsd"
+    xmlns:mstns="http://tempuri.org/default.xsd"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+>
+	   
+  <xs:complexType name="NestedTest_NestedType">
+    <xs:sequence>
+        <xs:element name="TestField" type="xs:string" />
+    </xs:sequence>
+  </xs:complexType>		   
+		   
+  <xs:complexType name="NestedTest_Type">
+    <xs:sequence>
+        <xs:element name="TestField" type="NestedTest_NestedType" minOccurs="0" maxOccurs="1" />
+        <xs:element name="TestCollectionField" type="NestedTest_NestedType" minOccurs="0" maxOccurs="unbounded" />
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/XmlSchemaClassGenerator/CodeUtilities.cs
+++ b/XmlSchemaClassGenerator/CodeUtilities.cs
@@ -269,11 +269,6 @@ namespace XmlSchemaClassGenerator
             var i = 0;
             foreach (var prop in classModel.Properties)
             {
-                if (!classModel.Configuration.EnableDataBinding && !(prop.Type is SimpleModel))
-                {
-                    continue;
-                }
-
                 if (propertyModel == prop)
                 {
                     i += 1;
@@ -399,7 +394,20 @@ namespace XmlSchemaClassGenerator
                 return typeRef;
             }
             else
-                return new CodeTypeReference(t, conf.CodeTypeReferenceOptions);
+            {
+                var typeRef = new CodeTypeReference(t, conf.CodeTypeReferenceOptions);
+
+                foreach (var typeArg in typeRef.TypeArguments)
+                {
+                    if (typeArg is CodeTypeReference typeArgRef)
+                    {
+                        typeArgRef.Options = conf.CodeTypeReferenceOptions;
+                    }
+                }
+
+                return typeRef;
+            }
+
         }
 
         public static CodeTypeReference CreateTypeReference(string namespaceName, string typeName, GeneratorConfiguration conf)


### PR DESCRIPTION
* any attribute is not rendered if complex type extends other complex type
* fix GlobalReference mode (`global::` gets rendered twice, collection of XmlAttribute rendered without `global::` prefix)
* fix duplicate backed value name