### PR TITLE
Add original XSD elements to INamingProvider methods

### DIFF
--- a/XmlSchemaClassGenerator/INamingProvider.cs
+++ b/XmlSchemaClassGenerator/INamingProvider.cs
@@ -1,6 +1,7 @@
 ﻿namespace XmlSchemaClassGenerator
 {
     using System.Xml;
+    using System.Xml.Schema;
 
     public interface INamingProvider
     {
@@ -9,39 +10,90 @@
         /// </summary>
         /// <param name="typeModelName">Name of the typeModel</param>
         /// <param name="attributeName">Attribute name</param>
+        /// <param name="attribute">Original XSD attribute</param>
         /// <returns>Name of the property</returns>
-        string PropertyNameFromAttribute(string typeModelName, string attributeName);
+        string PropertyNameFromAttribute(string typeModelName, string attributeName, XmlSchemaAttribute attribute);
 
         /// <summary>
         /// Creates a name for a property from an element name
         /// </summary>
         /// <param name="typeModelName">Name of the typeModel</param>
         /// <param name="elementName">Element name</param>
+        /// <param name="element">Original XSD element</param>
         /// <returns>Name of the property</returns>
-        string PropertyNameFromElement(string typeModelName, string elementName);
+        string PropertyNameFromElement(string typeModelName, string elementName, XmlSchemaElement element);
 
         /// <summary>
         /// Creates a name for an enum member based on a value
         /// </summary>
         /// <param name="enumName">Name of the enum</param>
         /// <param name="value">Value name</param>
+        /// <param name="xmlFacet">Original XSD enumeration facet</param>
         /// <returns>Name of the enum member</returns>
-        string EnumMemberNameFromValue(string enumName, string value);
+        string EnumMemberNameFromValue(string enumName, string value, XmlSchemaEnumerationFacet xmlFacet);
 
-        string ComplexTypeNameFromQualifiedName(XmlQualifiedName qualifiedName);
+        /// <summary>
+        /// Define the name to be used when a ComplexType is found in the XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="complexType">Original XSD ComplexType</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        string ComplexTypeNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaComplexType complexType);
 
-        string AttributeGroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName);
+        /// <summary>
+        /// Define the name to be used when a AttributeGroup is found in the XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="attributeGroup">Original XSD AttributeGroup</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        string AttributeGroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaAttributeGroup attributeGroup);
 
-        string GroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName);
+        /// <summary>
+        /// Define the name to be used when a GroupType is found in the XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="group">Original XSD group</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        string GroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaGroup group);
 
-        string SimpleTypeNameFromQualifiedName(XmlQualifiedName qualifiedName);
+        /// <summary>
+        /// Define the name to be used when a SimpleType is found in the XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="simpleType">Original XSD SimpleType</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        string SimpleTypeNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaSimpleType simpleType);
 
-        string RootClassNameFromQualifiedName(XmlQualifiedName qualifiedName);
+        /// <summary>
+        /// Define the name to be used for the root class.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="xmlElement">Original XSD element</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        string RootClassNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaElement xmlElement);
 
-        string EnumTypeNameFromQualifiedName(XmlQualifiedName qualifiedName);
+        /// <summary>
+        /// Define the name to be used when an enum type is found in the XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="xmlSimpleType">Original XSD SimpleType</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        string EnumTypeNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaSimpleType xmlSimpleType);
 
-        string AttributeNameFromQualifiedName(XmlQualifiedName qualifiedName);
+        /// <summary>
+        /// Define the name to be used when an attribute is found in the XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="xmlAttribute">Original XSD attribute</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        string AttributeNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaAttribute xmlAttribute);
 
-        string ElementNameFromQualifiedName(XmlQualifiedName qualifiedName);
+        /// <summary>
+        /// Define the name of the C# class property from the element name in XSD.
+        /// </summary>
+        /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="xmlElement">Original XSD element</param>
+        /// <returns>A string with a valid C# identifier name.</returns>
+        string ElementNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaElement xmlElement);
     }
 }

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -265,7 +265,7 @@ namespace XmlSchemaClassGenerator
 
                         derivedClassModel = new ClassModel(_configuration)
                         {
-                            Name = _configuration.NamingProvider.RootClassNameFromQualifiedName(rootElement.QualifiedName),
+                            Name = _configuration.NamingProvider.RootClassNameFromQualifiedName(rootElement.QualifiedName, rootElement),
                             Namespace = CreateNamespaceModel(elementSource, rootElement.QualifiedName)
                         };
 
@@ -291,7 +291,7 @@ namespace XmlSchemaClassGenerator
 
                             var originalClassModel = new ClassModel(_configuration)
                             {
-                                Name = _configuration.NamingProvider.RootClassNameFromQualifiedName(type.RootElementName),
+                                Name = _configuration.NamingProvider.RootClassNameFromQualifiedName(type.RootElementName, rootElement),
                                 Namespace = classModel.Namespace
                             };
 
@@ -404,7 +404,7 @@ namespace XmlSchemaClassGenerator
 
         private TypeModel CreateTypeModel(Uri source, XmlSchemaGroup group, NamespaceModel namespaceModel, XmlQualifiedName qualifiedName, List<DocumentationModel> docs)
         {
-            var name = "I" + _configuration.NamingProvider.GroupTypeNameFromQualifiedName(qualifiedName);
+            var name = "I" + _configuration.NamingProvider.GroupTypeNameFromQualifiedName(qualifiedName, group);
             if (namespaceModel != null) { name = namespaceModel.GetUniqueTypeName(name); }
 
             var interfaceModel = new InterfaceModel(_configuration)
@@ -438,7 +438,7 @@ namespace XmlSchemaClassGenerator
 
         private TypeModel CreateTypeModel(Uri source, XmlSchemaAttributeGroup attributeGroup, NamespaceModel namespaceModel, XmlQualifiedName qualifiedName, List<DocumentationModel> docs)
         {
-            var name = "I" + _configuration.NamingProvider.AttributeGroupTypeNameFromQualifiedName(qualifiedName);
+            var name = "I" + _configuration.NamingProvider.AttributeGroupTypeNameFromQualifiedName(qualifiedName, attributeGroup);
             if (namespaceModel != null) { name = namespaceModel.GetUniqueTypeName(name); }
 
             var interfaceModel = new InterfaceModel(_configuration)
@@ -470,7 +470,7 @@ namespace XmlSchemaClassGenerator
 
         private TypeModel CreateTypeModel(Uri source, XmlSchemaComplexType complexType, NamespaceModel namespaceModel, XmlQualifiedName qualifiedName, List<DocumentationModel> docs)
         {
-            var name = _configuration.NamingProvider.ComplexTypeNameFromQualifiedName(qualifiedName);
+            var name = _configuration.NamingProvider.ComplexTypeNameFromQualifiedName(qualifiedName, complexType);
             if (namespaceModel != null)
             {
                 name = namespaceModel.GetUniqueTypeName(name);
@@ -649,7 +649,7 @@ namespace XmlSchemaClassGenerator
                 if (isEnum)
                 {
                     // we got an enum
-                    var name = _configuration.NamingProvider.EnumTypeNameFromQualifiedName(qualifiedName);
+                    var name = _configuration.NamingProvider.EnumTypeNameFromQualifiedName(qualifiedName, simpleType);
                     if (namespaceModel != null) { name = namespaceModel.GetUniqueTypeName(name); }
 
                     var enumModel = new EnumModel(_configuration)
@@ -667,7 +667,7 @@ namespace XmlSchemaClassGenerator
                     {
                         var value = new EnumValueModel
                         {
-                            Name = _configuration.NamingProvider.EnumMemberNameFromValue(enumModel.Name, facet.Value),
+                            Name = _configuration.NamingProvider.EnumMemberNameFromValue(enumModel.Name, facet.Value, facet),
                             Value = facet.Value
                         };
 
@@ -699,7 +699,7 @@ namespace XmlSchemaClassGenerator
                 restrictions = GetRestrictions(facets, simpleType).Where(r => r != null).Sanitize().ToList();
             }
 
-            var simpleModelName = _configuration.NamingProvider.SimpleTypeNameFromQualifiedName(qualifiedName);
+            var simpleModelName = _configuration.NamingProvider.SimpleTypeNameFromQualifiedName(qualifiedName, simpleType);
             if (namespaceModel != null) { simpleModelName = namespaceModel.GetUniqueTypeName(simpleModelName); }
 
             var simpleModel = new SimpleModel(_configuration)
@@ -756,7 +756,7 @@ namespace XmlSchemaClassGenerator
                     if (attribute.Use != XmlSchemaUse.Prohibited)
                     {
                         var attributeQualifiedName = attribute.AttributeSchemaType.QualifiedName;
-                        var attributeName = _configuration.NamingProvider.AttributeNameFromQualifiedName(attribute.QualifiedName);
+                        var attributeName = _configuration.NamingProvider.AttributeNameFromQualifiedName(attribute.QualifiedName, attribute);
 
                         if (attribute.Parent is XmlSchemaAttributeGroup attributeGroup
                             && attributeGroup.QualifiedName != typeModel.XmlSchemaName
@@ -776,7 +776,7 @@ namespace XmlSchemaClassGenerator
                                 if (attributeQualifiedName.IsEmpty || string.IsNullOrEmpty(attributeQualifiedName.Namespace))
                                 {
                                     // inner type, have to generate a type name
-                                    var typeName = _configuration.NamingProvider.PropertyNameFromAttribute(typeModel.Name, attribute.QualifiedName.Name);
+                                    var typeName = _configuration.NamingProvider.PropertyNameFromAttribute(typeModel.Name, attribute.QualifiedName.Name, attribute);
                                     attributeQualifiedName = new XmlQualifiedName(typeName, typeModel.XmlSchemaName.Namespace);
                                     // try to avoid name clashes
                                     if (NameExists(attributeQualifiedName))
@@ -864,7 +864,7 @@ namespace XmlSchemaClassGenerator
                         {
                             // inner type, have to generate a type name
                             var typeModelName = xmlParticle is XmlSchemaGroupRef groupRef ? groupRef.RefName : typeModel.XmlSchemaName;
-                            var typeName = _configuration.NamingProvider.PropertyNameFromElement(typeModelName.Name, element.QualifiedName.Name);
+                            var typeName = _configuration.NamingProvider.PropertyNameFromElement(typeModelName.Name, element.QualifiedName.Name, element);
                             elementQualifiedName = new XmlQualifiedName(typeName, typeModel.XmlSchemaName.Namespace);
                             // try to avoid name clashes
                             if (NameExists(elementQualifiedName))
@@ -877,7 +877,7 @@ namespace XmlSchemaClassGenerator
                     }
 
                     var effectiveElement = substitute?.Element ?? element;
-                    var propertyName = _configuration.NamingProvider.ElementNameFromQualifiedName(effectiveElement.QualifiedName);
+                    var propertyName = _configuration.NamingProvider.ElementNameFromQualifiedName(effectiveElement.QualifiedName, effectiveElement);
                     var originalPropertyName = propertyName;
                     if (propertyName == typeModel.Name)
                     {

--- a/XmlSchemaClassGenerator/NamingProvider.cs
+++ b/XmlSchemaClassGenerator/NamingProvider.cs
@@ -1,6 +1,7 @@
 ﻿namespace XmlSchemaClassGenerator
 {
     using System.Xml;
+    using System.Xml.Schema;
 
     /// <summary>
     /// Provides options to customize member names
@@ -24,10 +25,11 @@
         /// </summary>
         /// <param name="typeModelName">Name of the typeModel</param>
         /// <param name="attributeName">Attribute name</param>
+        /// <param name="attribute">Original XSD attribute</param>
         /// <returns>Name of the property</returns>
-        public virtual string PropertyNameFromAttribute(string typeModelName, string attributeName)
+        public virtual string PropertyNameFromAttribute(string typeModelName, string attributeName, XmlSchemaAttribute attribute)
         {
-            return PropertyNameFromElement(typeModelName, attributeName);
+            return typeModelName.ToTitleCase(_namingScheme) + attributeName.ToTitleCase(_namingScheme);
         }
 
         /// <summary>
@@ -35,8 +37,9 @@
         /// </summary>
         /// <param name="typeModelName">Name of the typeModel</param>
         /// <param name="elementName">Element name</param>
+        /// <param name="element">Original XSD element</param>
         /// <returns>Name of the property</returns>
-        public virtual string PropertyNameFromElement(string typeModelName, string elementName)
+        public virtual string PropertyNameFromElement(string typeModelName, string elementName, XmlSchemaElement element)
         {
             return typeModelName.ToTitleCase(_namingScheme) + elementName.ToTitleCase(_namingScheme);
         }
@@ -46,8 +49,9 @@
         /// </summary>
         /// <param name="enumName">Name of the enum</param>
         /// <param name="value">Value name</param>
+        /// <param name="xmlFacet">Original XSD enumeration facet</param>
         /// <returns>Name of the enum member</returns>
-        public virtual string EnumMemberNameFromValue(string enumName, string value)
+        public virtual string EnumMemberNameFromValue(string enumName, string value, XmlSchemaEnumerationFacet xmlFacet)
         {
             return value.ToTitleCase(_namingScheme).ToNormalizedEnumName();
         }
@@ -56,8 +60,9 @@
         /// Define the name to be used when a ComplexType is found in the XSD.
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="complexType">Original XSD ComplexType</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public virtual string ComplexTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string ComplexTypeNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaComplexType complexType)
         {
             return QualifiedNameToTitleCase(qualifiedName);
         }
@@ -66,8 +71,9 @@
         /// Define the name to be used when a AttributeGroup is found in the XSD.
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="attributeGroup">Original XSD AttributeGroup</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public virtual string AttributeGroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string AttributeGroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaAttributeGroup attributeGroup)
         {
             return QualifiedNameToTitleCase(qualifiedName);
         }
@@ -76,8 +82,9 @@
         /// Define the name to be used when a GroupType is found in the XSD.
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="group">Original XSD group</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public virtual string GroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string GroupTypeNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaGroup group)
         {
             return QualifiedNameToTitleCase(qualifiedName);
         }
@@ -86,8 +93,9 @@
         /// Define the name to be used when a SimpleType is found in the XSD.
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="simpleType">Original XSD SimpleType</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public virtual string SimpleTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string SimpleTypeNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaSimpleType simpleType)
         {
             return QualifiedNameToTitleCase(qualifiedName);
         }
@@ -96,8 +104,9 @@
         /// Define the name to be used for the root class.
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="xmlElement">Original XSD element</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public virtual string RootClassNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string RootClassNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaElement xmlElement)
         {
             return QualifiedNameToTitleCase(qualifiedName);
         }
@@ -106,8 +115,9 @@
         /// Define the name to be used when an enum type is found in the XSD.
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="xmlSimpleType">Original XSD SimpleType</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public virtual string EnumTypeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string EnumTypeNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaSimpleType xmlSimpleType)
         {
             return QualifiedNameToTitleCase(qualifiedName);
         }
@@ -116,8 +126,9 @@
         /// Define the name to be used when an attribute is found in the XSD.
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="xmlAttribute">Original XSD attribute</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public virtual string AttributeNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string AttributeNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaAttribute xmlAttribute)
         {
             return QualifiedNameToTitleCase(qualifiedName);
         }
@@ -126,8 +137,9 @@
         /// Define the name of the C# class property from the element name in XSD.
         /// </summary>
         /// <param name="qualifiedName">The name as defined in the XSD if present.</param>
+        /// <param name="xmlElement">Original XSD element</param>
         /// <returns>A string with a valid C# identifier name.</returns>
-        public virtual string ElementNameFromQualifiedName(XmlQualifiedName qualifiedName)
+        public virtual string ElementNameFromQualifiedName(XmlQualifiedName qualifiedName, XmlSchemaElement xmlElement)
         {
             return QualifiedNameToTitleCase(qualifiedName);
         }


### PR DESCRIPTION
Fixes #293.

Note that this is not a backward-compatible improvement (`INamingProvider` interface is changed). Unfortunately, I don't have any good ideas on how to make it backward-compatible (except a separate interface and new configuration option, which looks pretty silly to me).