### PR TITLE
Avoid XmlElementAttribute creation for Properties created via a ref=""

### DIFF
--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -1810,10 +1810,10 @@ namespace Test
             Assert.NotNull(classType);
 
             var directProperty = Assert.Single(classType.GetProperties().Where(p => p.Name == "Direct"));
-            Assert.NotEmpty(directProperty.GetCustomAttributes<XmlElementAttribute>());
+            Assert.Equal(XmlSchemaForm.Unqualified, directProperty.GetCustomAttributes<XmlElementAttribute>().FirstOrDefault()?.Form);
 
             var viaRefProperty = Assert.Single(classType.GetProperties().Where(p => p.Name == "ViaRef"));
-            Assert.Empty(viaRefProperty.GetCustomAttributes<XmlElementAttribute>());
+            Assert.Equal(XmlSchemaForm.None, viaRefProperty.GetCustomAttributes<XmlElementAttribute>().FirstOrDefault()?.Form);
         }
 
         [Fact]

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -912,13 +912,22 @@ namespace XmlSchemaClassGenerator
                         IsCollection = item.MaxOccurs > 1.0m || particle.MaxOccurs > 1.0m, // http://msdn.microsoft.com/en-us/library/vstudio/d3hx2s7e(v=vs.100).aspx
                         DefaultValue = element.DefaultValue ?? ((item.MinOccurs >= 1.0m && item.XmlParent is not XmlSchemaChoice) ? element.FixedValue : null),
                         FixedValue = element.FixedValue,
-                        Form = element.Form == XmlSchemaForm.None ? element.GetSchema().ElementFormDefault : element.Form,
                         XmlNamespace = !string.IsNullOrEmpty(effectiveElement.QualifiedName.Namespace) && effectiveElement.QualifiedName.Namespace != typeModel.XmlSchemaName.Namespace
                             ? effectiveElement.QualifiedName.Namespace : null,
                         XmlParticle = item.XmlParticle,
                         XmlParent = item.XmlParent,
                         Particle = item
                     };
+
+                    if (element.Form == XmlSchemaForm.None)
+                    {
+                        if (element.RefName != null && !element.RefName.IsEmpty)
+                            property.Form = XmlSchemaForm.Qualified;
+                        else
+                            property.Form = element.GetSchema().ElementFormDefault;
+                    }
+                    else
+                        property.Form = element.Form;
 
                     if (property.IsArray && !_configuration.GenerateComplexTypesForCollections)
                     {


### PR DESCRIPTION
potentially a fix for https://github.com/mganss/XmlSchemaClassGenerator/issues/303

This is only a failing unit test for now