### PR TITLE
Fix invalid interface generated for attribute group containing attribute with list type

### DIFF
--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -2578,5 +2578,91 @@ namespace Test
             var optionList = applicationType.GetProperty("OptionList");
             Assert.Equal("Test_Generation_Namespace.T_OptionList", optionList.PropertyType.FullName);
         }
+
+        [Fact]
+        public void CollectionSetterInAttributeGroupInterfaceIsPrivateIfCollectionSetterModeIsPrivate()
+        {
+            const string xsd = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<xs:schema xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <xs:element name=""Element"">
+    <xs:complexType>
+      <xs:attributeGroup ref=""AttrGroup""/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:attributeGroup name=""AttrGroup"">
+    <xs:attribute name=""Attr"">
+      <xs:simpleType>
+        <xs:list itemType=""xs:int""/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+</xs:schema>";
+
+            var generator = new Generator
+            {
+                NamespaceProvider = new NamespaceProvider
+                {
+                    GenerateNamespace = key => "Test",
+                },
+                GenerateInterfaces = true,
+                CollectionSettersMode = CollectionSettersMode.Private
+            };
+            var contents = ConvertXml(nameof(CollectionSetterInAttributeGroupInterfaceIsPrivateIfCollectionSetterModeIsPrivate), xsd, generator).ToArray();
+            var assembly = Compiler.Compile(nameof(CollectionSetterInAttributeGroupInterfaceIsPrivateIfCollectionSetterModeIsPrivate), contents);
+
+            var interfaceProperty = assembly.GetType("Test.IAttrGroup")?.GetProperty("Attr");
+            var implementerProperty = assembly.GetType("Test.Element")?.GetProperty("Attr");
+            Assert.NotNull(interfaceProperty);
+            Assert.NotNull(implementerProperty);
+
+            var interfaceHasPublicSetter = interfaceProperty.GetSetMethod() != null;
+            var implementerHasPublicSetter = implementerProperty.GetSetMethod() != null;
+            Assert.False(interfaceHasPublicSetter);
+            Assert.False(implementerHasPublicSetter);
+        }
+
+        [Fact]
+        public void CollectionSetterInAttributeGroupInterfaceIsPublicIfCollectionSetterModeIsPublic()
+        {
+            const string xsd = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<xs:schema xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+  <xs:element name=""Element"">
+    <xs:complexType>
+      <xs:attributeGroup ref=""AttrGroup""/>
+    </xs:complexType>
+  </xs:element>
+
+  <xs:attributeGroup name=""AttrGroup"">
+    <xs:attribute name=""Attr"">
+      <xs:simpleType>
+        <xs:list itemType=""xs:int""/>
+      </xs:simpleType>
+    </xs:attribute>
+  </xs:attributeGroup>
+</xs:schema>";
+
+            var generator = new Generator
+            {
+                NamespaceProvider = new NamespaceProvider
+                {
+                    GenerateNamespace = key => "Test",
+                },
+                GenerateInterfaces = true,
+                CollectionSettersMode = CollectionSettersMode.Public
+            };
+            var contents = ConvertXml(nameof(CollectionSetterInAttributeGroupInterfaceIsPublicIfCollectionSetterModeIsPublic), xsd, generator).ToArray();
+            var assembly = Compiler.Compile(nameof(CollectionSetterInAttributeGroupInterfaceIsPublicIfCollectionSetterModeIsPublic), contents);
+
+            var interfaceProperty = assembly.GetType("Test.IAttrGroup")?.GetProperty("Attr");
+            var implementerProperty = assembly.GetType("Test.Element")?.GetProperty("Attr");
+            Assert.NotNull(interfaceProperty);
+            Assert.NotNull(implementerProperty);
+
+            var interfaceHasPublicSetter = interfaceProperty.GetSetMethod() != null;
+            var implementerHasPublicSetter = implementerProperty.GetSetMethod() != null;
+            Assert.True(interfaceHasPublicSetter);
+            Assert.True(implementerHasPublicSetter);
+        }
     }
 }

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -781,6 +781,15 @@ namespace XmlSchemaClassGenerator
             }
         }
 
+        private bool IsPrivateSetter
+        {
+            get
+            {
+                return Configuration.CollectionSettersMode == CollectionSettersMode.Private
+                    && (IsCollection || IsArray || (IsList && IsAttribute));
+            }
+        }
+
         private CodeTypeReference TypeReference
         {
             get
@@ -825,9 +834,9 @@ namespace XmlSchemaClassGenerator
         {
             CodeTypeMember member;
 
-            var isArray = IsArray;
             var propertyType = PropertyType;
             var isNullableValueType = IsNullableValueType;
+            var isPrivateSetter = IsPrivateSetter;
             var typeReference = TypeReference;
 
             if (isNullableValueType && Configuration.GenerateNullables)
@@ -842,7 +851,7 @@ namespace XmlSchemaClassGenerator
                 Name = Name,
                 Type = typeReference,
                 HasGet = true,
-                HasSet = !IsCollection && !isArray
+                HasSet = !isPrivateSetter
             };
 
             if (DefaultValue != null && IsNullable)
@@ -872,6 +881,7 @@ namespace XmlSchemaClassGenerator
             var propertyType = PropertyType;
             var isNullableValueType = IsNullableValueType;
             var isNullableReferenceType = IsNullableReferenceType;
+            var isPrivateSetter = IsPrivateSetter;
             var typeReference = TypeReference;
 
             var requiresBackingField = withDataBinding || DefaultValue != null || IsCollection || isArray;
@@ -934,8 +944,6 @@ namespace XmlSchemaClassGenerator
                 }
                 else
                     member = new CodeMemberField(typeReference, propertyName);
-
-                var isPrivateSetter = (IsCollection || isArray || (IsList && IsAttribute)) && Configuration.CollectionSettersMode == CollectionSettersMode.Private;
 
                 if (requiresBackingField)
                 {


### PR DESCRIPTION
Fixes #325.

Correct logic was already implemented in the function used to generate interfaces for "normal" groups. This logic was moved to a property so that it can be used to generate correct interfaces for both attribute groups and "normal" groups.