### PR TITLE
Fixed NRT issues and tidied code.

### DIFF
--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -2399,7 +2399,7 @@ namespace Test
                 Assert.Equal(nullable, hasMaybeNullAttribute);
             }
             assertNullable("Test.ElementReferenceNullable", true);
-            assertNullable("Test.ElementReferenceList", true);
+            assertNullable("Test.ElementReferenceList", false);
             assertNullable("Test.ElementReferenceNonNullable", false);
             assertNullable("Test.AttributeReferenceNullable", true);
             assertNullable("Test.AttributeReferenceNonNullable", false);

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -29,7 +29,7 @@ namespace XmlSchemaClassGenerator
             _configuration = configuration;
             _set = set;
 
-            DocumentationModel.DisableComments = _configuration.DisableComments;
+            GeneratorModel.DisableComments = _configuration.DisableComments;
             var objectModel = new SimpleModel(_configuration)
             {
                 Name = "AnyType",


### PR DESCRIPTION
Fixes #332 and #333 

While I was at it, I couldn't help myself from modernising and tidying up the code:
- Avoid hard-coded strings.
- `new()`
- pattern matching
- helper methods to avoid duplication

Removed about 500 lines of code.

All tests passing except `XsdElsterDatenabholung5.CanCompileClasses` due to missing files.