### PR TITLE
Not-Null Arrays when using `--nullableReferenceAttributes`

### DIFF
--- a/XmlSchemaClassGenerator/Extensions.cs
+++ b/XmlSchemaClassGenerator/Extensions.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml.Schema;
 
 namespace XmlSchemaClassGenerator
@@ -12,31 +9,18 @@ namespace XmlSchemaClassGenerator
     {
         public static XmlSchema GetSchema(this XmlSchemaObject xmlSchemaObject)
         {
-            while (xmlSchemaObject != null && !(xmlSchemaObject is XmlSchema))
+            while (xmlSchemaObject is not null and not XmlSchema)
                 xmlSchemaObject = xmlSchemaObject.Parent;
             return (XmlSchema)xmlSchemaObject;
         }
 
-        public static PropertyValueTypeCode GetPropertyValueTypeCode(this TypeModel model)
+        public static PropertyValueTypeCode GetPropertyValueTypeCode(this TypeModel model) => model switch
         {
-            if (model is not SimpleModel simpleType)
-            {
-                if (!(model is EnumModel))
-                {
-                    return PropertyValueTypeCode.Other;
-                }
-                return PropertyValueTypeCode.ValueType;
-            }
-            if (simpleType.ValueType.IsArray)
-            {
-                return PropertyValueTypeCode.Array;
-            }
-            if (simpleType.ValueType.IsValueType)
-            {
-                return PropertyValueTypeCode.ValueType;
-            }
-            return PropertyValueTypeCode.Other;
-        }
+            SimpleModel { ValueType.IsArray: true } => PropertyValueTypeCode.Array,
+            SimpleModel { ValueType.IsValueType: true } => PropertyValueTypeCode.ValueType,
+            SimpleModel or not EnumModel => PropertyValueTypeCode.Other,
+            _ => PropertyValueTypeCode.ValueType
+        };
 
         public static IEnumerable<TSource> DistinctBy<TSource, TKey>(this IEnumerable<TSource> source, Func<TSource, TKey> propertySelector)
         {
@@ -45,17 +29,9 @@ namespace XmlSchemaClassGenerator
 
         public static string QuoteIfNeeded(this string text)
         {
-            if (string.IsNullOrEmpty(text))
-            {
-                return text;
-            }
-
-            if (text.Contains(" "))
-            {
-                return "\"" + text + "\"";
-            }
-
-            return text;
+            return string.IsNullOrEmpty(text) ? text
+                 : text.Contains(" ") ? "\"" + text + "\""
+                 : text;
         }
     }
 }

--- a/XmlSchemaClassGenerator/IXmlSchemaNode.cs
+++ b/XmlSchemaClassGenerator/IXmlSchemaNode.cs
@@ -1,0 +1,81 @@
+﻿using System.Xml;
+using System.Xml.Schema;
+
+namespace XmlSchemaClassGenerator
+{
+    public interface IXmlSchemaNode
+    {
+        string Name { get; }
+        string DefaultValue { get; }
+        string FixedValue { get; }
+        XmlSchemaForm Form { get; }
+        XmlQualifiedName QualifiedName { get; }
+        XmlQualifiedName RefName { get; }
+        XmlSchemaType SchemaType { get; }
+        XmlSchemaType NodeSchemaType { get; }
+        XmlQualifiedName SchemaTypeName { get; }
+
+        XmlSchemaAnnotated Base { get; }
+        XmlSchemaForm FormDefault { get; }
+    }
+
+    public sealed class XmlSchemaAttributeEx : IXmlSchemaNode
+    {
+        private XmlSchemaAttributeEx(XmlSchemaAttribute xs) => Real = xs;
+
+        public XmlSchemaAttribute Real { get; }
+
+        public string Name => Real.Name;
+        public string DefaultValue => Real.DefaultValue;
+        public string FixedValue => Real.FixedValue;
+        public XmlSchemaForm Form => Real.Form;
+        public XmlQualifiedName QualifiedName => Real.QualifiedName;
+        public XmlQualifiedName RefName => Real.RefName;
+        public XmlQualifiedName SchemaTypeName => Real.SchemaTypeName;
+        public XmlSchemaSimpleType SchemaType => Real.SchemaType;
+        public XmlSchemaSimpleType AttributeSchemaType => Real.AttributeSchemaType;
+
+        public XmlSchemaAnnotated Base => Real;
+
+        public XmlSchemaForm FormDefault => Base.GetSchema().AttributeFormDefault;
+
+        XmlSchemaType IXmlSchemaNode.SchemaType => SchemaType;
+
+        XmlSchemaType IXmlSchemaNode.NodeSchemaType => AttributeSchemaType;
+
+        public XmlSchemaUse Use => Real.Use;
+
+        public static implicit operator XmlSchemaAttributeEx(XmlSchemaAttribute xs) => new(xs);
+        public static implicit operator XmlSchemaAttribute(XmlSchemaAttributeEx ex) => ex.Real;
+    }
+
+    public sealed class XmlSchemaElementEx : IXmlSchemaNode
+    {
+        private XmlSchemaElementEx(XmlSchemaElement xs) => Real = xs;
+
+        public XmlSchemaElement Real { get; }
+
+        public string Name => Real.Name;
+        public string DefaultValue => Real.DefaultValue;
+        public string FixedValue => Real.FixedValue;
+        public XmlSchemaForm Form => Real.Form;
+        public XmlQualifiedName QualifiedName => Real.QualifiedName;
+        public XmlQualifiedName RefName => Real.RefName;
+        public XmlQualifiedName SchemaTypeName => Real.SchemaTypeName;
+        public XmlSchemaType SchemaType => Real.SchemaType;
+        public XmlSchemaType ElementSchemaType => Real.ElementSchemaType;
+
+        public XmlSchemaAnnotated Base => Real;
+
+        public XmlSchemaForm FormDefault => Base.GetSchema().ElementFormDefault;
+
+        XmlSchemaType IXmlSchemaNode.SchemaType => SchemaType;
+
+        XmlSchemaType IXmlSchemaNode.NodeSchemaType => ElementSchemaType;
+
+        public bool IsNillable => Real.IsNillable;
+
+        public static implicit operator XmlSchemaElementEx(XmlSchemaElement xs) => new(xs);
+        public static implicit operator XmlSchemaElement(XmlSchemaElementEx ex) => ex.Real;
+    }
+}

--- a/XmlSchemaClassGenerator/IXmlSchemaNode.cs
+++ b/XmlSchemaClassGenerator/IXmlSchemaNode.cs
@@ -5,15 +5,15 @@ namespace XmlSchemaClassGenerator
 {
     public interface IXmlSchemaNode
     {
-        string Name { get; }
+        //string Name { get; }
         string DefaultValue { get; }
         string FixedValue { get; }
         XmlSchemaForm Form { get; }
         XmlQualifiedName QualifiedName { get; }
         XmlQualifiedName RefName { get; }
-        XmlSchemaType SchemaType { get; }
-        XmlSchemaType NodeSchemaType { get; }
-        XmlQualifiedName SchemaTypeName { get; }
+        //XmlQualifiedName SchemaTypeName { get; }
+        //XmlSchemaType SchemaType { get; }
+        //XmlSchemaType NodeSchemaType { get; }
 
         XmlSchemaAnnotated Base { get; }
         XmlSchemaForm FormDefault { get; }
@@ -25,23 +25,23 @@ namespace XmlSchemaClassGenerator
 
         public XmlSchemaAttribute Real { get; }
 
-        public string Name => Real.Name;
+        //public string Name => Real.Name;
         public string DefaultValue => Real.DefaultValue;
         public string FixedValue => Real.FixedValue;
         public XmlSchemaForm Form => Real.Form;
         public XmlQualifiedName QualifiedName => Real.QualifiedName;
         public XmlQualifiedName RefName => Real.RefName;
-        public XmlQualifiedName SchemaTypeName => Real.SchemaTypeName;
-        public XmlSchemaSimpleType SchemaType => Real.SchemaType;
+        //public XmlQualifiedName SchemaTypeName => Real.SchemaTypeName;
+        //public XmlSchemaSimpleType SchemaType => Real.SchemaType;
         public XmlSchemaSimpleType AttributeSchemaType => Real.AttributeSchemaType;
 
         public XmlSchemaAnnotated Base => Real;
 
         public XmlSchemaForm FormDefault => Base.GetSchema().AttributeFormDefault;
 
-        XmlSchemaType IXmlSchemaNode.SchemaType => SchemaType;
+        //XmlSchemaType IXmlSchemaNode.SchemaType => SchemaType;
 
-        XmlSchemaType IXmlSchemaNode.NodeSchemaType => AttributeSchemaType;
+        //XmlSchemaType IXmlSchemaNode.NodeSchemaType => AttributeSchemaType;
 
         public XmlSchemaUse Use => Real.Use;
 
@@ -55,23 +55,23 @@ namespace XmlSchemaClassGenerator
 
         public XmlSchemaElement Real { get; }
 
-        public string Name => Real.Name;
+        //public string Name => Real.Name;
         public string DefaultValue => Real.DefaultValue;
         public string FixedValue => Real.FixedValue;
         public XmlSchemaForm Form => Real.Form;
         public XmlQualifiedName QualifiedName => Real.QualifiedName;
         public XmlQualifiedName RefName => Real.RefName;
-        public XmlQualifiedName SchemaTypeName => Real.SchemaTypeName;
-        public XmlSchemaType SchemaType => Real.SchemaType;
+        //public XmlQualifiedName SchemaTypeName => Real.SchemaTypeName;
+        //public XmlSchemaType SchemaType => Real.SchemaType;
         public XmlSchemaType ElementSchemaType => Real.ElementSchemaType;
 
         public XmlSchemaAnnotated Base => Real;
 
         public XmlSchemaForm FormDefault => Base.GetSchema().ElementFormDefault;
 
-        XmlSchemaType IXmlSchemaNode.SchemaType => SchemaType;
+        //XmlSchemaType IXmlSchemaNode.SchemaType => SchemaType;
 
-        XmlSchemaType IXmlSchemaNode.NodeSchemaType => ElementSchemaType;
+        //XmlSchemaType IXmlSchemaNode.NodeSchemaType => ElementSchemaType;
 
         public bool IsNillable => Real.IsNillable;
 

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -755,9 +755,9 @@ namespace XmlSchemaClassGenerator
 
             foreach (var item in items)
             {
-                if (item is XmlSchemaAttribute node)
+                if (item is XmlSchemaAttribute xs)
                 {
-                    XmlSchemaAttributeEx attribute = node;
+                    XmlSchemaAttributeEx attribute = xs;
                     if (attribute.Use != XmlSchemaUse.Prohibited)
                     {
                         var attributeQualifiedName = attribute.AttributeSchemaType.QualifiedName;
@@ -806,10 +806,10 @@ namespace XmlSchemaClassGenerator
                         var property = new PropertyModel(_configuration, name, typeModel, owningTypeModel)
                         {
                             IsAttribute = true,
-                            IsRequired = node.Use == XmlSchemaUse.Required
+                            IsRequired = attribute.Use == XmlSchemaUse.Required
                         };
 
-                        property.SetFromNode(originalName, () => node.Use != XmlSchemaUse.Optional, attribute);
+                        property.SetFromNode(originalName, () => attribute.Use != XmlSchemaUse.Optional, attribute);
                         property.SetSchemaNameAndNamespace(owningTypeModel, attribute);
                         property.Documentation.AddRange(GetDocumentation(attribute));
 
@@ -865,7 +865,7 @@ namespace XmlSchemaClassGenerator
                 if (item.XmlParticle is XmlSchemaElement xs && xs.ElementSchemaType != null)
                 {
                     XmlSchemaElementEx element = xs;
-                    XmlSchemaElementEx effectiveElement = substitute?.Element ?? xs;
+                    XmlSchemaElementEx effectiveElement = substitute?.Element ?? element;
                     var name = _configuration.NamingProvider.ElementNameFromQualifiedName(effectiveElement.QualifiedName, effectiveElement);
                     var originalName = name;
                     if (name == owningTypeModel.Name)
@@ -873,9 +873,9 @@ namespace XmlSchemaClassGenerator
 
                     name = owningTypeModel.GetUniquePropertyName(name);
 
-                    var typeModel = substitute?.Type ?? CreateTypeModel(GetQualifiedName(owningTypeModel, xmlParticle, xs), xs.ElementSchemaType);
+                    var typeModel = substitute?.Type ?? CreateTypeModel(GetQualifiedName(owningTypeModel, xmlParticle, element), element.ElementSchemaType);
 
-                    property = new PropertyModel(_configuration, name, typeModel, owningTypeModel) { IsNillable = xs.IsNillable };
+                    property = new PropertyModel(_configuration, name, typeModel, owningTypeModel) { IsNillable = element.IsNillable };
                     property.SetFromParticles(particle, item);
                     property.SetFromNode(originalName, () => item.MinOccurs >= 1.0m && item.XmlParent is not XmlSchemaChoice, element);
                     property.SetSchemaNameAndNamespace(owningTypeModel, effectiveElement);

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -23,6 +23,9 @@ namespace XmlSchemaClassGenerator
         private string BuildKey(XmlSchemaAnnotated annotated, XmlQualifiedName name)
             => $"{annotated.GetType()}:{annotated.SourceUri}:{annotated.LineNumber}:{annotated.LinePosition}:{name}";
 
+        private void SetType(XmlSchemaAnnotated annotated, XmlQualifiedName name, TypeModel type)
+            => Types[BuildKey(annotated, name)] = type;
+
         public ModelBuilder(GeneratorConfiguration configuration, XmlSchemaSet set)
         {
             _configuration = configuration;
@@ -39,8 +42,7 @@ namespace XmlSchemaClassGenerator
                 UseDataTypeAttribute = false
             };
 
-            var key = BuildKey(new XmlSchemaComplexType(), AnyType);
-            Types[key] = objectModel;
+            SetType(new XmlSchemaComplexType(), AnyType, objectModel);
 
             AttributeGroups = set.Schemas().Cast<XmlSchema>().SelectMany(s => s.AttributeGroups.Values.Cast<XmlSchemaAttributeGroup>())
                 .DistinctBy(g => g.QualifiedName.ToString())
@@ -52,16 +54,15 @@ namespace XmlSchemaClassGenerator
             var dependencyOrder = new List<XmlSchema>();
             var seenSchemas = new HashSet<XmlSchema>();
             foreach (var schema in set.Schemas().Cast<XmlSchema>())
-            {
                 ResolveDependencies(schema, dependencyOrder, seenSchemas);
-            }
 
             foreach (var schema in dependencyOrder)
             {
-                var types = set.GlobalTypes.Values.Cast<XmlSchemaType>().Where(s => s.GetSchema() == schema);
-                CreateTypes(types);
-                var elements = set.GlobalElements.Values.Cast<XmlSchemaElement>().Where(s => s.GetSchema() == schema);
-                CreateElements(elements);
+                foreach (var globalType in set.GlobalTypes.Values.Cast<XmlSchemaType>().Where(s => s.GetSchema() == schema))
+                    CreateTypeModel(globalType.QualifiedName, globalType);
+
+                foreach (var rootElement in set.GlobalElements.Values.Cast<XmlSchemaElement>().Where(s => s.GetSchema() == schema))
+                    CreateElement(rootElement);
             }
 
             CreateSubstitutes();
@@ -147,9 +148,7 @@ namespace XmlSchemaClassGenerator
                     continue;
                 }
                 foreach (var typeModel in types)
-                {
                     typeModel.RootElementName = typeModel.GetQualifiedName();
-                }
             }
         }
 
@@ -164,9 +163,7 @@ namespace XmlSchemaClassGenerator
                     {
                         var baseProperties = baseInterfaceTypeProperties.ToList();
                         foreach (var baseProperty in baseProperties.Where(baseProperty => parentProperty.Name == baseProperty.Name && parentProperty.Type.Name == baseProperty.Type.Name))
-                        {
                             baseInterfaceTypeProperties.Remove(baseProperty);
-                        }
                     }
                 }
             }
@@ -208,9 +205,7 @@ namespace XmlSchemaClassGenerator
                     if (derivedProperties.Any(p => p.IsCollection))
                     {
                         foreach (var derivedProperty in derivedProperties.Where(p => !p.IsCollection))
-                        {
                             derivedProperty.IsCollection = true;
-                        }
 
                         interfaceProperty.IsCollection = true;
                     }
@@ -224,9 +219,7 @@ namespace XmlSchemaClassGenerator
             foreach (var derivedClass in interfaceModel.AllDerivedReferenceTypes().Where(c => c != implementationClass))
             {
                 foreach (var propertyModel in derivedClass.Properties.Where(p => p.Name == interfaceProperty.Name))
-                {
                     propertyModel.Name = newName;
-                }
             }
         }
 
@@ -251,125 +244,113 @@ namespace XmlSchemaClassGenerator
             dependencyOrder.Add(schema);
         }
 
-        private void CreateTypes(IEnumerable<XmlSchemaType> types)
+        private void CreateElement(XmlSchemaElement rootElement)
         {
-            foreach (var globalType in types)
+            var qualifiedName = rootElement.ElementSchemaType.QualifiedName;
+            if (qualifiedName.IsEmpty)
+                qualifiedName = rootElement.QualifiedName;
+            var type = CreateTypeModel(qualifiedName, rootElement.ElementSchemaType);
+            ClassModel derivedClassModel = null;
+
+            if (type.RootElementName != null || type.IsAbstractRoot)
             {
-                CreateTypeModel(globalType.QualifiedName, globalType);
+                if (type is ClassModel classModel)
+                    derivedClassModel = CreateDerivedRootClass(rootElement, type, classModel);
+                else
+                    SetType(rootElement, rootElement.QualifiedName, type);
+            }
+            else
+            {
+                if (type is ClassModel classModel)
+                    classModel.Documentation.AddRange(GetDocumentation(rootElement));
+
+                type.RootElement = rootElement;
+                type.RootElementName = rootElement.QualifiedName;
+            }
+
+            if (!rootElement.SubstitutionGroup.IsEmpty)
+            {
+                if (!SubstitutionGroups.TryGetValue(rootElement.SubstitutionGroup, out var substitutes))
+                {
+                    substitutes = new HashSet<Substitute>();
+                    SubstitutionGroups.Add(rootElement.SubstitutionGroup, substitutes);
+                }
+
+                substitutes.Add(new Substitute { Element = rootElement, Type = derivedClassModel ?? type });
             }
         }
 
-        private void CreateElements(IEnumerable<XmlSchemaElement> elements)
+        private ClassModel CreateDerivedRootClass(XmlSchemaElement rootElement, TypeModel type, ClassModel classModel)
         {
-            foreach (var rootElement in elements)
+            ClassModel derivedClassModel;
+            // There is already another global element with this type.
+            // Need to create an empty derived class.
+
+            var elementSource = CodeUtilities.CreateUri(rootElement.SourceUri);
+
+            derivedClassModel = new ClassModel(_configuration)
             {
-                var qualifiedName = rootElement.ElementSchemaType.QualifiedName;
-                if (qualifiedName.IsEmpty) { qualifiedName = rootElement.QualifiedName; }
-                var type = CreateTypeModel(qualifiedName, rootElement.ElementSchemaType);
-                ClassModel derivedClassModel = null;
+                Name = _configuration.NamingProvider.RootClassNameFromQualifiedName(rootElement.QualifiedName, rootElement),
+                Namespace = CreateNamespaceModel(elementSource, rootElement.QualifiedName)
+            };
 
-                if (type.RootElementName != null || type.IsAbstractRoot)
-                {
-                    if (type is ClassModel classModel)
-                    {
-                        // There is already another global element with this type.
-                        // Need to create an empty derived class.
+            derivedClassModel.Documentation.AddRange(GetDocumentation(rootElement));
 
-                        var elementSource = CodeUtilities.CreateUri(rootElement.SourceUri);
-
-                        derivedClassModel = new ClassModel(_configuration)
-                        {
-                            Name = _configuration.NamingProvider.RootClassNameFromQualifiedName(rootElement.QualifiedName, rootElement),
-                            Namespace = CreateNamespaceModel(elementSource, rootElement.QualifiedName)
-                        };
-
-                        derivedClassModel.Documentation.AddRange(GetDocumentation(rootElement));
-
-                        if (derivedClassModel.Namespace != null)
-                        {
-                            derivedClassModel.Name = derivedClassModel.Namespace.GetUniqueTypeName(derivedClassModel.Name);
-                            derivedClassModel.Namespace.Types[derivedClassModel.Name] = derivedClassModel;
-                        }
-
-                        var key = BuildKey(rootElement, rootElement.QualifiedName);
-                        Types[key] = derivedClassModel;
-
-                        derivedClassModel.BaseClass = classModel;
-                        ((ClassModel)derivedClassModel.BaseClass).DerivedTypes.Add(derivedClassModel);
-
-                        derivedClassModel.RootElementName = rootElement.QualifiedName;
-
-                        if (!type.IsAbstractRoot)
-                        {
-                            // Also create an empty derived class for the original root element
-
-                            var originalClassModel = new ClassModel(_configuration)
-                            {
-                                Name = _configuration.NamingProvider.RootClassNameFromQualifiedName(type.RootElementName, rootElement),
-                                Namespace = classModel.Namespace
-                            };
-
-                            originalClassModel.Documentation.AddRange(classModel.Documentation);
-                            classModel.Documentation.Clear();
-
-                            if (originalClassModel.Namespace != null)
-                            {
-                                originalClassModel.Name = originalClassModel.Namespace.GetUniqueTypeName(originalClassModel.Name);
-                                originalClassModel.Namespace.Types[originalClassModel.Name] = originalClassModel;
-                            }
-
-                            if (classModel.XmlSchemaName?.IsEmpty == false)
-                            {
-                                key = BuildKey(classModel.RootElement, classModel.XmlSchemaName);
-                                Types[key] = originalClassModel;
-                            }
-
-                            originalClassModel.BaseClass = classModel;
-                            ((ClassModel)originalClassModel.BaseClass).DerivedTypes.Add(originalClassModel);
-
-                            originalClassModel.RootElementName = type.RootElementName;
-
-                            if (classModel.RootElement.SubstitutionGroup != null
-                                && SubstitutionGroups.TryGetValue(classModel.RootElement.SubstitutionGroup, out var substitutes))
-                            {
-                                foreach (var substitute in substitutes.Where(s => s.Element == classModel.RootElement))
-                                {
-                                    substitute.Type = originalClassModel;
-                                }
-                            }
-
-                            classModel.RootElementName = null;
-                            classModel.IsAbstractRoot = true;
-                        }
-                    }
-                    else
-                    {
-                        var key = BuildKey(rootElement, rootElement.QualifiedName);
-                        Types[key] = type;
-                    }
-                }
-                else
-                {
-                    if (type is ClassModel classModel)
-                    {
-                        classModel.Documentation.AddRange(GetDocumentation(rootElement));
-                    }
-
-                    type.RootElement = rootElement;
-                    type.RootElementName = rootElement.QualifiedName;
-                }
-
-                if (!rootElement.SubstitutionGroup.IsEmpty)
-                {
-                    if (!SubstitutionGroups.TryGetValue(rootElement.SubstitutionGroup, out var substitutes))
-                    {
-                        substitutes = new HashSet<Substitute>();
-                        SubstitutionGroups.Add(rootElement.SubstitutionGroup, substitutes);
-                    }
-
-                    substitutes.Add(new Substitute { Element = rootElement, Type = derivedClassModel ?? type });
-                }
+            if (derivedClassModel.Namespace != null)
+            {
+                derivedClassModel.Name = derivedClassModel.Namespace.GetUniqueTypeName(derivedClassModel.Name);
+                derivedClassModel.Namespace.Types[derivedClassModel.Name] = derivedClassModel;
             }
+
+            SetType(rootElement, rootElement.QualifiedName, derivedClassModel);
+
+            derivedClassModel.BaseClass = classModel;
+            ((ClassModel)derivedClassModel.BaseClass).DerivedTypes.Add(derivedClassModel);
+
+            derivedClassModel.RootElementName = rootElement.QualifiedName;
+
+            if (!type.IsAbstractRoot)
+                CreateOriginalRootClass(rootElement, type, classModel);
+
+            return derivedClassModel;
+        }
+
+        private void CreateOriginalRootClass(XmlSchemaElement rootElement, TypeModel type, ClassModel classModel)
+        {
+            // Also create an empty derived class for the original root element
+
+            var originalClassModel = new ClassModel(_configuration)
+            {
+                Name = _configuration.NamingProvider.RootClassNameFromQualifiedName(type.RootElementName, rootElement),
+                Namespace = classModel.Namespace
+            };
+
+            originalClassModel.Documentation.AddRange(classModel.Documentation);
+            classModel.Documentation.Clear();
+
+            if (originalClassModel.Namespace != null)
+            {
+                originalClassModel.Name = originalClassModel.Namespace.GetUniqueTypeName(originalClassModel.Name);
+                originalClassModel.Namespace.Types[originalClassModel.Name] = originalClassModel;
+            }
+
+            if (classModel.XmlSchemaName?.IsEmpty == false)
+                SetType(classModel.RootElement, classModel.XmlSchemaName, originalClassModel);
+
+            originalClassModel.BaseClass = classModel;
+            ((ClassModel)originalClassModel.BaseClass).DerivedTypes.Add(originalClassModel);
+
+            originalClassModel.RootElementName = type.RootElementName;
+
+            if (classModel.RootElement.SubstitutionGroup != null
+                && SubstitutionGroups.TryGetValue(classModel.RootElement.SubstitutionGroup, out var substitutes))
+            {
+                foreach (var substitute in substitutes.Where(s => s.Element == classModel.RootElement))
+                    substitute.Type = originalClassModel;
+            }
+
+            classModel.RootElementName = null;
+            classModel.IsAbstractRoot = true;
         }
 
         private IEnumerable<Substitute> GetSubstitutedElements(XmlQualifiedName name)
@@ -394,359 +375,410 @@ namespace XmlSchemaClassGenerator
             var namespaceModel = CreateNamespaceModel(source, qualifiedName);
             var docs = GetDocumentation(type);
 
-            return type switch
+            var typeModelBuilder = new TypeModelBuilder(this, _configuration, qualifiedName, namespaceModel, docs, source);
+
+            return typeModelBuilder.Create(type);
+        }
+
+        private class TypeModelBuilder
+        {
+            private readonly ModelBuilder builder;
+            private readonly GeneratorConfiguration _configuration;
+            private readonly XmlQualifiedName qualifiedName;
+            private readonly NamespaceModel namespaceModel;
+            private readonly List<DocumentationModel> docs;
+            private readonly Uri source;
+
+            public TypeModelBuilder(ModelBuilder builder, GeneratorConfiguration configuration, XmlQualifiedName qualifiedName, NamespaceModel namespaceModel, List<DocumentationModel> docs, Uri source)
             {
-                XmlSchemaGroup group => CreateTypeModel(qualifiedName, namespaceModel, docs, source, group),
-                XmlSchemaAttributeGroup attributeGroup => CreateTypeModel(qualifiedName, namespaceModel, docs, source, attributeGroup),
-                XmlSchemaComplexType complexType => CreateTypeModel(qualifiedName, namespaceModel, docs, source, complexType),
-                XmlSchemaSimpleType simpleType => CreateTypeModel(qualifiedName, namespaceModel, docs, simpleType),
+                this.builder = builder;
+                _configuration = configuration;
+                this.qualifiedName = qualifiedName;
+                this.namespaceModel = namespaceModel;
+                this.docs = docs;
+                this.source = source;
+            }
+
+            internal TypeModel Create(XmlSchemaAnnotated type) => type switch
+            {
+                XmlSchemaGroup group => CreateTypeModel(group),
+                XmlSchemaAttributeGroup attributeGroup => CreateTypeModel(attributeGroup),
+                XmlSchemaComplexType complexType => CreateTypeModel(complexType),
+                XmlSchemaSimpleType simpleType => CreateTypeModel(simpleType),
                 _ => throw new NotSupportedException($"Cannot build declaration for {qualifiedName}"),
             };
-        }
 
-        private TypeModel CreateTypeModel(XmlQualifiedName qualifiedName, NamespaceModel namespaceModel, List<DocumentationModel> docs, Uri source, XmlSchemaGroup group)
-        {
-            var name = "I" + _configuration.NamingProvider.GroupTypeNameFromQualifiedName(qualifiedName, group);
-            if (namespaceModel != null) { name = namespaceModel.GetUniqueTypeName(name); }
-
-            var interfaceModel = new InterfaceModel(_configuration)
+            private InterfaceModel CreateInterfaceModel(XmlSchemaAnnotated group, string name)
             {
-                Name = name,
-                Namespace = namespaceModel,
-                XmlSchemaName = qualifiedName
-            };
+                if (namespaceModel != null)
+                    name = namespaceModel.GetUniqueTypeName(name);
 
-            interfaceModel.Documentation.AddRange(docs);
-
-            if (namespaceModel != null) { namespaceModel.Types[name] = interfaceModel; }
-
-            if (!qualifiedName.IsEmpty)
-            {
-                var key = BuildKey(group, qualifiedName);
-                Types[key] = interfaceModel;
-            }
-
-            var xmlParticle = group.Particle;
-            var particle = new Particle(xmlParticle, group.Parent);
-            var items = GetElements(xmlParticle);
-            var properties = CreatePropertiesForElements(source, interfaceModel, particle, items.Where(i => i.XmlParticle is not XmlSchemaGroupRef));
-            interfaceModel.Properties.AddRange(properties);
-            var interfaces = items.Select(i => i.XmlParticle).OfType<XmlSchemaGroupRef>()
-                .Select(i => (InterfaceModel)CreateTypeModel(i.RefName, Groups[i.RefName]));
-            interfaceModel.AddInterfaces(interfaces);
-
-            return interfaceModel;
-        }
-
-        private TypeModel CreateTypeModel(XmlQualifiedName qualifiedName, NamespaceModel namespaceModel, List<DocumentationModel> docs, Uri source, XmlSchemaAttributeGroup attributeGroup)
-        {
-            var name = "I" + _configuration.NamingProvider.AttributeGroupTypeNameFromQualifiedName(qualifiedName, attributeGroup);
-            if (namespaceModel != null) { name = namespaceModel.GetUniqueTypeName(name); }
-
-            var interfaceModel = new InterfaceModel(_configuration)
-            {
-                Name = name,
-                Namespace = namespaceModel,
-                XmlSchemaName = qualifiedName
-            };
-
-            interfaceModel.Documentation.AddRange(docs);
-
-            if (namespaceModel != null) { namespaceModel.Types[name] = interfaceModel; }
-
-            if (!qualifiedName.IsEmpty)
-            {
-                var key = BuildKey(attributeGroup, qualifiedName);
-                Types[key] = interfaceModel;
-            }
-
-            var items = attributeGroup.Attributes;
-            var properties = CreatePropertiesForAttributes(source, interfaceModel, items.OfType<XmlSchemaAttribute>());
-            interfaceModel.Properties.AddRange(properties);
-            var interfaces = items.OfType<XmlSchemaAttributeGroupRef>()
-                .Select(a => (InterfaceModel)CreateTypeModel(a.RefName, AttributeGroups[a.RefName]));
-            interfaceModel.AddInterfaces(interfaces);
-
-            return interfaceModel;
-        }
-
-        private TypeModel CreateTypeModel(XmlQualifiedName qualifiedName, NamespaceModel namespaceModel, List<DocumentationModel> docs, Uri source, XmlSchemaComplexType complexType)
-        {
-            var name = _configuration.NamingProvider.ComplexTypeNameFromQualifiedName(qualifiedName, complexType);
-            if (namespaceModel != null)
-            {
-                name = namespaceModel.GetUniqueTypeName(name);
-            }
-
-            var classModel = new ClassModel(_configuration)
-            {
-                Name = name,
-                Namespace = namespaceModel,
-                XmlSchemaName = qualifiedName,
-                XmlSchemaType = complexType,
-                IsAbstract = complexType.IsAbstract,
-                IsAnonymous = string.IsNullOrEmpty(complexType.QualifiedName.Name),
-                IsMixed = complexType.IsMixed,
-                IsSubstitution = complexType.Parent is XmlSchemaElement parent && !parent.SubstitutionGroup.IsEmpty
-            };
-
-            classModel.Documentation.AddRange(docs);
-
-            if (namespaceModel != null)
-            {
-                namespaceModel.Types[classModel.Name] = classModel;
-            }
-
-            if (!qualifiedName.IsEmpty)
-            {
-                var key = BuildKey(complexType, qualifiedName);
-                Types[key] = classModel;
-            }
-
-            if (complexType.BaseXmlSchemaType != null && complexType.BaseXmlSchemaType.QualifiedName != AnyType)
-            {
-                var baseModel = CreateTypeModel(complexType.BaseXmlSchemaType.QualifiedName, complexType.BaseXmlSchemaType);
-                classModel.BaseClass = baseModel;
-                if (baseModel is ClassModel baseClassModel) { baseClassModel.DerivedTypes.Add(classModel); }
-            }
-
-            XmlSchemaParticle xmlParticle = null;
-            if (classModel.BaseClass != null)
-            {
-                if (complexType.ContentModel.Content is XmlSchemaComplexContentExtension complexContent)
+                var interfaceModel = new InterfaceModel(_configuration)
                 {
-                    xmlParticle = complexContent.Particle;
-                }
-
-                // If it's a restriction, do not duplicate elements on the derived class, they're already in the base class.
-                // See https://msdn.microsoft.com/en-us/library/f3z3wh0y.aspx
-            }
-            else
-            {
-                xmlParticle = complexType.Particle ?? complexType.ContentTypeParticle;
-            }
-
-            var items = GetElements(xmlParticle, complexType).ToList();
-
-            if (_configuration.GenerateInterfaces)
-            {
-                var interfaces = items.Select(i => i.XmlParticle).OfType<XmlSchemaGroupRef>()
-                    .Select(i => (InterfaceModel)CreateTypeModel(i.RefName, Groups[i.RefName])).ToList();
-
-                classModel.AddInterfaces(interfaces);
-            }
-
-            var particle = new Particle(xmlParticle, xmlParticle?.Parent);
-            var properties = CreatePropertiesForElements(source, classModel, particle, items);
-            classModel.Properties.AddRange(properties);
-
-            XmlSchemaObjectCollection attributes = null;
-            if (classModel.BaseClass != null)
-            {
-                if (complexType.ContentModel.Content is XmlSchemaComplexContentExtension complexContent)
-                {
-                    attributes = complexContent.Attributes;
-                }
-                else if (complexType.ContentModel.Content is XmlSchemaSimpleContentExtension simpleContent)
-                {
-                    attributes = simpleContent.Attributes;
-                }
-
-                // If it's a restriction, do not duplicate attributes on the derived class, they're already in the base class.
-                // See https://msdn.microsoft.com/en-us/library/f3z3wh0y.aspx
-            }
-            else
-            {
-                attributes = complexType.Attributes;
-
-                if (attributes.Count == 0 && complexType.ContentModel != null)
-                {
-                    var content = complexType.ContentModel.Content;
-
-                    if (content is XmlSchemaComplexContentExtension extension)
-                        attributes = extension.Attributes;
-                    else if (content is XmlSchemaComplexContentRestriction restriction)
-                        attributes = restriction.Attributes;
-                }
-            }
-
-            if (attributes != null)
-            {
-                var attributeProperties = CreatePropertiesForAttributes(source, classModel, attributes.Cast<XmlSchemaObject>());
-                classModel.Properties.AddRange(attributeProperties);
-
-                if (_configuration.GenerateInterfaces)
-                {
-                    var attributeInterfaces = attributes.OfType<XmlSchemaAttributeGroupRef>()
-                        .Select(i => (InterfaceModel)CreateTypeModel(i.RefName, AttributeGroups[i.RefName]));
-                    classModel.AddInterfaces(attributeInterfaces);
-                }
-            }
-
-            XmlSchemaAnyAttribute anyAttribute = null;
-            if (complexType.AnyAttribute != null)
-            {
-                anyAttribute = complexType.AnyAttribute;
-            }
-            else if (complexType.AttributeWildcard != null)
-            {
-                var hasAnyAttribute = true;
-                for (var baseType = complexType.BaseXmlSchemaType; baseType != null; baseType = baseType.BaseXmlSchemaType)
-                {
-                    if (baseType is not XmlSchemaComplexType baseComplexType)
-                        continue;
-
-                    if (baseComplexType.AttributeWildcard != null)
-                    {
-                        hasAnyAttribute = false;
-                        break;
-                    }
-                }
-
-                if (hasAnyAttribute)
-                    anyAttribute = complexType.AttributeWildcard;
-            }
-
-            if (anyAttribute != null)
-            {
-                SimpleModel type = new(_configuration) { ValueType = typeof(XmlAttribute), UseDataTypeAttribute = false };
-                var property = new PropertyModel(_configuration, "AnyAttribute", type, classModel)
-                {
-                    IsAttribute = true,
-                    IsCollection = true,
-                    IsAny = true
+                    Name = name,
+                    Namespace = namespaceModel,
+                    XmlSchemaName = qualifiedName
                 };
 
-                var attributeDocs = GetDocumentation(anyAttribute);
-                property.Documentation.AddRange(attributeDocs);
+                interfaceModel.Documentation.AddRange(docs);
 
-                classModel.Properties.Add(property);
+                if (namespaceModel != null)
+                    namespaceModel.Types[name] = interfaceModel;
+
+                if (!qualifiedName.IsEmpty)
+                    builder.SetType(group, qualifiedName, interfaceModel);
+                return interfaceModel;
             }
 
-            return classModel;
-        }
-
-        private TypeModel CreateTypeModel(XmlQualifiedName qualifiedName, NamespaceModel namespaceModel, List<DocumentationModel> docs, XmlSchemaSimpleType simpleType)
-        {
-            var restrictions = new List<RestrictionModel>();
-            var allBasesHaveEnums = true;
-            List<XmlSchemaFacet> facets = new();
-
-            if (simpleType.Content is XmlSchemaSimpleTypeRestriction typeRestriction)
+            private TypeModel CreateTypeModel(XmlSchemaGroup group)
             {
-                facets = typeRestriction.Facets.Cast<XmlSchemaFacet>().ToList();
-            }
-            else if (simpleType.Content is XmlSchemaSimpleTypeUnion typeUnion
-                && typeUnion.BaseMemberTypes.All(b => b.Content is XmlSchemaSimpleTypeRestriction r && r.Facets.Count > 0))
-            {
-                var baseFacets = typeUnion.BaseMemberTypes.Select(b => ((XmlSchemaSimpleTypeRestriction)b.Content).Facets.Cast<XmlSchemaFacet>()).ToList();
-                // if a union has enum restrictions, there must be an enum restriction in all parts of the union
-                allBasesHaveEnums = baseFacets.All(fs => fs.OfType<XmlSchemaEnumerationFacet>().Any());
-                facets = baseFacets.SelectMany(f => f).ToList();
+                var name = "I" + _configuration.NamingProvider.GroupTypeNameFromQualifiedName(qualifiedName, group);
+
+                InterfaceModel interfaceModel = CreateInterfaceModel(group, name);
+
+                var xmlParticle = group.Particle;
+                var particle = new Particle(xmlParticle, group.Parent);
+                var items = builder.GetElements(xmlParticle);
+                var properties = builder.CreatePropertiesForElements(source, interfaceModel, particle, items.Where(i => i.XmlParticle is not XmlSchemaGroupRef));
+                interfaceModel.Properties.AddRange(properties);
+                AddInterfaces(interfaceModel, items);
+
+                return interfaceModel;
             }
 
-            if (facets.Count > 0)
+            private TypeModel CreateTypeModel(XmlSchemaAttributeGroup group)
             {
-                var enumFacets = facets.OfType<XmlSchemaEnumerationFacet>().ToList();
-                // If there are other restrictions mixed into the enumeration values, we'll generate a string to play it safe.
-                var isEnum = enumFacets.Count > 0 && allBasesHaveEnums;
+                var name = "I" + _configuration.NamingProvider.AttributeGroupTypeNameFromQualifiedName(qualifiedName, group);
 
-                if (isEnum)
+                InterfaceModel interfaceModel = CreateInterfaceModel(group, name);
+
+                var attributes = group.Attributes;
+                var properties = builder.CreatePropertiesForAttributes(source, interfaceModel, attributes.OfType<XmlSchemaAttribute>());
+                interfaceModel.Properties.AddRange(properties);
+                AddInterfaces(interfaceModel, attributes);
+
+                return interfaceModel;
+            }
+
+            private TypeModel CreateTypeModel(XmlSchemaComplexType complexType)
+            {
+                var name = _configuration.NamingProvider.ComplexTypeNameFromQualifiedName(qualifiedName, complexType);
+                if (namespaceModel != null)
+                    name = namespaceModel.GetUniqueTypeName(name);
+
+                var classModel = new ClassModel(_configuration)
                 {
-                    // we got an enum
-                    var name = _configuration.NamingProvider.EnumTypeNameFromQualifiedName(qualifiedName, simpleType);
-                    if (namespaceModel != null) { name = namespaceModel.GetUniqueTypeName(name); }
+                    Name = name,
+                    Namespace = namespaceModel,
+                    XmlSchemaName = qualifiedName,
+                    XmlSchemaType = complexType,
+                    IsAbstract = complexType.IsAbstract,
+                    IsAnonymous = string.IsNullOrEmpty(complexType.QualifiedName.Name),
+                    IsMixed = complexType.IsMixed,
+                    IsSubstitution = complexType.Parent is XmlSchemaElement parent && !parent.SubstitutionGroup.IsEmpty
+                };
 
-                    var enumModel = new EnumModel(_configuration)
+                classModel.Documentation.AddRange(docs);
+
+                if (namespaceModel != null)
+                    namespaceModel.Types[classModel.Name] = classModel;
+
+                if (!qualifiedName.IsEmpty)
+                    builder.SetType(complexType, qualifiedName, classModel);
+
+                if (complexType.BaseXmlSchemaType != null && complexType.BaseXmlSchemaType.QualifiedName != AnyType)
+                {
+                    var baseModel = builder.CreateTypeModel(complexType.BaseXmlSchemaType.QualifiedName, complexType.BaseXmlSchemaType);
+                    classModel.BaseClass = baseModel;
+                    if (baseModel is ClassModel baseClassModel)
+                        baseClassModel.DerivedTypes.Add(classModel);
+                }
+
+                XmlSchemaParticle xmlParticle = null;
+                if (classModel.BaseClass != null)
+                {
+                    if (complexType.ContentModel.Content is XmlSchemaComplexContentExtension complexContent)
+                        xmlParticle = complexContent.Particle;
+
+                    // If it's a restriction, do not duplicate elements on the derived class, they're already in the base class.
+                    // See https://msdn.microsoft.com/en-us/library/f3z3wh0y.aspx
+                }
+                else
+                {
+                    xmlParticle = complexType.Particle ?? complexType.ContentTypeParticle;
+                }
+
+                var items = builder.GetElements(xmlParticle, complexType).ToList();
+
+                if (_configuration.GenerateInterfaces)
+                    AddInterfaces(classModel, items);
+
+                var particle = new Particle(xmlParticle, xmlParticle?.Parent);
+                var properties = builder.CreatePropertiesForElements(source, classModel, particle, items);
+                classModel.Properties.AddRange(properties);
+
+                XmlSchemaObjectCollection attributes = null;
+                if (classModel.BaseClass != null)
+                {
+                    if (complexType.ContentModel.Content is XmlSchemaComplexContentExtension complexContent)
+                        attributes = complexContent.Attributes;
+                    else if (complexType.ContentModel.Content is XmlSchemaSimpleContentExtension simpleContent)
+                        attributes = simpleContent.Attributes;
+
+                    // If it's a restriction, do not duplicate attributes on the derived class, they're already in the base class.
+                    // See https://msdn.microsoft.com/en-us/library/f3z3wh0y.aspx
+                }
+                else
+                {
+                    attributes = complexType.Attributes;
+
+                    if (attributes.Count == 0 && complexType.ContentModel != null)
                     {
-                        Name = name,
-                        Namespace = namespaceModel,
-                        XmlSchemaName = qualifiedName,
-                        XmlSchemaType = simpleType,
-                        IsAnonymous = string.IsNullOrEmpty(simpleType.QualifiedName.Name),
+                        var content = complexType.ContentModel.Content;
+
+                        if (content is XmlSchemaComplexContentExtension extension)
+                            attributes = extension.Attributes;
+                        else if (content is XmlSchemaComplexContentRestriction restriction)
+                            attributes = restriction.Attributes;
+                    }
+                }
+
+                if (attributes != null)
+                {
+                    var attributeProperties = builder.CreatePropertiesForAttributes(source, classModel, attributes.Cast<XmlSchemaObject>());
+                    classModel.Properties.AddRange(attributeProperties);
+
+                    if (_configuration.GenerateInterfaces)
+                        AddInterfaces(classModel, items);
+                }
+
+                XmlSchemaAnyAttribute anyAttribute = null;
+                if (complexType.AnyAttribute != null)
+                {
+                    anyAttribute = complexType.AnyAttribute;
+                }
+                else if (complexType.AttributeWildcard != null)
+                {
+                    var hasAnyAttribute = true;
+                    for (var baseType = complexType.BaseXmlSchemaType; baseType != null; baseType = baseType.BaseXmlSchemaType)
+                    {
+                        if (baseType is not XmlSchemaComplexType baseComplexType)
+                            continue;
+
+                        if (baseComplexType.AttributeWildcard != null)
+                        {
+                            hasAnyAttribute = false;
+                            break;
+                        }
+                    }
+
+                    if (hasAnyAttribute)
+                        anyAttribute = complexType.AttributeWildcard;
+                }
+
+                if (anyAttribute != null)
+                {
+                    SimpleModel type = new(_configuration) { ValueType = typeof(XmlAttribute), UseDataTypeAttribute = false };
+                    var property = new PropertyModel(_configuration, "AnyAttribute", type, classModel)
+                    {
+                        IsAttribute = true,
+                        IsCollection = true,
+                        IsAny = true
                     };
 
-                    enumModel.Documentation.AddRange(docs);
+                    var attributeDocs = GetDocumentation(anyAttribute);
+                    property.Documentation.AddRange(attributeDocs);
 
-                    foreach (var facet in enumFacets.DistinctBy(f => f.Value))
-                    {
-                        var value = new EnumValueModel
-                        {
-                            Name = _configuration.NamingProvider.EnumMemberNameFromValue(enumModel.Name, facet.Value, facet),
-                            Value = facet.Value
-                        };
-
-                        var valueDocs = GetDocumentation(facet);
-                        value.Documentation.AddRange(valueDocs);
-
-                        value.IsDeprecated = facet.Annotation?.Items.OfType<XmlSchemaAppInfo>()
-                            .Any(a => a.Markup.Any(m => m.Name == "annox:annotate" && m.HasChildNodes && m.FirstChild.Name == "jl:Deprecated")) == true;
-
-                        enumModel.Values.Add(value);
-                    }
-
-                    enumModel.Values = EnsureEnumValuesUnique(enumModel.Values);
-                    if (namespaceModel != null)
-                    {
-                        namespaceModel.Types[enumModel.Name] = enumModel;
-                    }
-
-                    if (!qualifiedName.IsEmpty)
-                    {
-                        var key = BuildKey(simpleType, qualifiedName);
-                        Types[key] = enumModel;
-                    }
-
-                    return enumModel;
+                    classModel.Properties.Add(property);
                 }
 
-                restrictions = GetRestrictions(facets, simpleType).Where(r => r != null).Sanitize().ToList();
+                return classModel;
             }
 
-            var simpleModelName = _configuration.NamingProvider.SimpleTypeNameFromQualifiedName(qualifiedName, simpleType);
-            if (namespaceModel != null) { simpleModelName = namespaceModel.GetUniqueTypeName(simpleModelName); }
-
-            var simpleModel = new SimpleModel(_configuration)
+            private TypeModel CreateTypeModel(XmlSchemaSimpleType simpleType)
             {
-                Name = simpleModelName,
-                Namespace = namespaceModel,
-                XmlSchemaName = qualifiedName,
-                XmlSchemaType = simpleType,
-                ValueType = simpleType.Datatype.GetEffectiveType(_configuration, restrictions),
-            };
+                List<RestrictionModel> restrictions = null;
+                List<IEnumerable<XmlSchemaFacet>> baseFacets = null;
 
-            simpleModel.Documentation.AddRange(docs);
-            simpleModel.Restrictions.AddRange(restrictions);
-
-            if (namespaceModel != null)
-            {
-                namespaceModel.Types[simpleModel.Name] = simpleModel;
-            }
-
-            if (!qualifiedName.IsEmpty)
-            {
-                var key = BuildKey(simpleType, qualifiedName);
-                Types[key] = simpleModel;
-            }
-
-            return simpleModel;
-        }
-
-        private static List<EnumValueModel> EnsureEnumValuesUnique(List<EnumValueModel> enumModelValues)
-        {
-            var enumValueGroups = from enumValue in enumModelValues
-                                  group enumValue by enumValue.Name;
-
-            foreach (var g in enumValueGroups)
-            {
-                var i = 1;
-                foreach (var t in g.Skip(1))
+                var facets = simpleType.Content switch
                 {
-                    t.Name = $"{t.Name}{i++}";
+                    XmlSchemaSimpleTypeRestriction typeRestriction => typeRestriction.Facets.Cast<XmlSchemaFacet>().ToList(),
+                    XmlSchemaSimpleTypeUnion typeUnion when AllMembersHaveFacets(typeUnion, out baseFacets) => baseFacets.SelectMany(f => f).ToList(),
+                    _ => new(),
+                };
+
+                if (facets.Count > 0)
+                {
+                    var enumFacets = facets.OfType<XmlSchemaEnumerationFacet>().ToList();
+
+                    // If a union has enum restrictions, there must be an enum restriction in all parts of the union
+                    // If there are other restrictions mixed into the enumeration values, we'll generate a string to play it safe.
+                    if (enumFacets.Count > 0 && (baseFacets is null || baseFacets.All(fs => fs.OfType<XmlSchemaEnumerationFacet>().Any())))
+                        return CreateEnumModel(simpleType, enumFacets);
+
+                    restrictions = GetRestrictions(facets, simpleType).Where(r => r != null).Sanitize().ToList();
+                }
+
+                return CreateSimpleModel(simpleType, restrictions ?? new());
+
+                static bool AllMembersHaveFacets(XmlSchemaSimpleTypeUnion typeUnion, out List<IEnumerable<XmlSchemaFacet>> baseFacets)
+                {
+                    var members = typeUnion.BaseMemberTypes.Select(b => b.Content as XmlSchemaSimpleTypeRestriction);
+                    var retval = members.All(r => r?.Facets.Count > 0);
+                    baseFacets = !retval ? null : members.Select(r => r.Facets.Cast<XmlSchemaFacet>()).ToList();
+                    return retval;
                 }
             }
 
-            return enumModelValues;
+            private IEnumerable<RestrictionModel> GetRestrictions(IEnumerable<XmlSchemaFacet> facets, XmlSchemaSimpleType type)
+            {
+                var min = facets.OfType<XmlSchemaMinLengthFacet>().Select(f => int.Parse(f.Value)).DefaultIfEmpty().Max();
+                var max = facets.OfType<XmlSchemaMaxLengthFacet>().Select(f => int.Parse(f.Value)).DefaultIfEmpty().Min();
+
+                if (_configuration.DataAnnotationMode == DataAnnotationMode.All)
+                {
+                    if (min > 0) yield return new MinLengthRestrictionModel(_configuration) { Value = min };
+                    if (max > 0) yield return new MaxLengthRestrictionModel(_configuration) { Value = max };
+                }
+                else if (min > 0 || max > 0)
+                {
+                    yield return new MinMaxLengthRestrictionModel(_configuration) { Min = min, Max = max };
+                }
+
+                foreach (var facet in facets)
+                {
+                    var valueType = type.Datatype.ValueType;
+                    switch (facet)
+                    {
+                        case XmlSchemaLengthFacet:
+                            var value = int.Parse(facet.Value);
+                            if (_configuration.DataAnnotationMode == DataAnnotationMode.All)
+                            {
+                                yield return new MinLengthRestrictionModel(_configuration) { Value = value };
+                                yield return new MaxLengthRestrictionModel(_configuration) { Value = value };
+                            }
+                            else
+                            {
+                                yield return new MinMaxLengthRestrictionModel(_configuration) { Min = value, Max = value };
+                            }
+                            break;
+                        case XmlSchemaTotalDigitsFacet:
+                            yield return new TotalDigitsRestrictionModel(_configuration) { Value = int.Parse(facet.Value) }; break;
+                        case XmlSchemaFractionDigitsFacet:
+                            yield return new FractionDigitsRestrictionModel(_configuration) { Value = int.Parse(facet.Value) }; break;
+                        case XmlSchemaPatternFacet:
+                            yield return new PatternRestrictionModel(_configuration) { Value = facet.Value }; break;
+                        case XmlSchemaMinInclusiveFacet:
+                            yield return new MinInclusiveRestrictionModel(_configuration) { Value = facet.Value, Type = valueType }; break;
+                        case XmlSchemaMinExclusiveFacet:
+                            yield return new MinExclusiveRestrictionModel(_configuration) { Value = facet.Value, Type = valueType }; break;
+                        case XmlSchemaMaxInclusiveFacet:
+                            yield return new MaxInclusiveRestrictionModel(_configuration) { Value = facet.Value, Type = valueType }; break;
+                        case XmlSchemaMaxExclusiveFacet:
+                            yield return new MaxExclusiveRestrictionModel(_configuration) { Value = facet.Value, Type = valueType }; break;
+                    }
+                }
+            }
+
+            private static List<EnumValueModel> EnsureEnumValuesUnique(List<EnumValueModel> enumModelValues)
+            {
+                var enumValueGroups = from enumValue in enumModelValues
+                                      group enumValue by enumValue.Name;
+
+                foreach (var g in enumValueGroups)
+                {
+                    var i = 1;
+                    foreach (var t in g.Skip(1))
+                        t.Name = $"{t.Name}{i++}";
+                }
+
+                return enumModelValues;
+            }
+
+            private EnumModel CreateEnumModel(XmlSchemaSimpleType simpleType, List<XmlSchemaEnumerationFacet> enumFacets)
+            {
+                // we got an enum
+                var name = _configuration.NamingProvider.EnumTypeNameFromQualifiedName(qualifiedName, simpleType);
+                if (namespaceModel != null)
+                    name = namespaceModel.GetUniqueTypeName(name);
+
+                var enumModel = new EnumModel(_configuration)
+                {
+                    Name = name,
+                    Namespace = namespaceModel,
+                    XmlSchemaName = qualifiedName,
+                    XmlSchemaType = simpleType,
+                    IsAnonymous = string.IsNullOrEmpty(simpleType.QualifiedName.Name),
+                };
+
+                enumModel.Documentation.AddRange(docs);
+
+                foreach (var facet in enumFacets.DistinctBy(f => f.Value))
+                {
+                    var value = new EnumValueModel
+                    {
+                        Name = _configuration.NamingProvider.EnumMemberNameFromValue(enumModel.Name, facet.Value, facet),
+                        Value = facet.Value
+                    };
+
+                    var valueDocs = GetDocumentation(facet);
+                    value.Documentation.AddRange(valueDocs);
+
+                    value.IsDeprecated = facet.Annotation?.Items.OfType<XmlSchemaAppInfo>()
+                        .Any(a => a.Markup.Any(m => m.Name == "annox:annotate" && m.HasChildNodes && m.FirstChild.Name == "jl:Deprecated")) == true;
+
+                    enumModel.Values.Add(value);
+                }
+
+                enumModel.Values = EnsureEnumValuesUnique(enumModel.Values);
+                if (namespaceModel != null)
+                    namespaceModel.Types[enumModel.Name] = enumModel;
+
+                if (!qualifiedName.IsEmpty)
+                    builder.SetType(simpleType, qualifiedName, enumModel);
+
+                return enumModel;
+            }
+
+            private SimpleModel CreateSimpleModel(XmlSchemaSimpleType simpleType, List<RestrictionModel> restrictions)
+            {
+                var simpleModelName = _configuration.NamingProvider.SimpleTypeNameFromQualifiedName(qualifiedName, simpleType);
+                if (namespaceModel != null)
+                    simpleModelName = namespaceModel.GetUniqueTypeName(simpleModelName);
+
+                var simpleModel = new SimpleModel(_configuration)
+                {
+                    Name = simpleModelName,
+                    Namespace = namespaceModel,
+                    XmlSchemaName = qualifiedName,
+                    XmlSchemaType = simpleType,
+                    ValueType = simpleType.Datatype.GetEffectiveType(_configuration, restrictions),
+                };
+
+                simpleModel.Documentation.AddRange(docs);
+                simpleModel.Restrictions.AddRange(restrictions);
+
+                if (namespaceModel != null)
+                    namespaceModel.Types[simpleModel.Name] = simpleModel;
+
+                if (!qualifiedName.IsEmpty)
+                    builder.SetType(simpleType, qualifiedName, simpleModel);
+                return simpleModel;
+            }
+
+            private void AddInterfaces(ReferenceTypeModel refTypeModel, IEnumerable<Particle> items)
+            {
+                var interfaces = items.Select(i => i.XmlParticle).OfType<XmlSchemaGroupRef>()
+                    .Select(i => (InterfaceModel)builder.CreateTypeModel(i.RefName, builder.Groups[i.RefName]));
+                refTypeModel.AddInterfaces(interfaces);
+            }
+
+            private void AddInterfaces(ReferenceTypeModel refTypeModel, XmlSchemaObjectCollection attributes)
+            {
+                var interfaces = attributes.OfType<XmlSchemaAttributeGroupRef>()
+                    .Select(a => (InterfaceModel)builder.CreateTypeModel(a.RefName, builder.AttributeGroups[a.RefName]));
+                refTypeModel.AddInterfaces(interfaces);
+            }
         }
 
         private IEnumerable<PropertyModel> CreatePropertiesForAttributes(Uri source, TypeModel owningTypeModel, IEnumerable<XmlSchemaObject> items)
@@ -755,163 +787,129 @@ namespace XmlSchemaClassGenerator
 
             foreach (var item in items)
             {
-                if (item is XmlSchemaAttribute xs)
+                switch (item)
                 {
-                    XmlSchemaAttributeEx attribute = xs;
-                    if (attribute.Use != XmlSchemaUse.Prohibited)
-                    {
-                        var attributeQualifiedName = attribute.AttributeSchemaType.QualifiedName;
-                        var name = _configuration.NamingProvider.AttributeNameFromQualifiedName(attribute.QualifiedName, attribute);
-                        var originalName = name;
+                    case XmlSchemaAttribute attribute when attribute.Use != XmlSchemaUse.Prohibited:
+                        properties.Add(PropertyFromAttribute(owningTypeModel, attribute));
+                        break;
+                    case XmlSchemaAttributeGroupRef attributeGroupRef:
+                        if (_configuration.GenerateInterfaces)
+                            CreateTypeModel(attributeGroupRef.RefName, AttributeGroups[attributeGroupRef.RefName]);
 
-                        if (attribute.Base.Parent is XmlSchemaAttributeGroup attributeGroup
-                            && attributeGroup.QualifiedName != owningTypeModel.XmlSchemaName
-                            && Types.TryGetValue(BuildKey(attributeGroup, attributeGroup.QualifiedName), out var typeModelValue)
-                            && typeModelValue is InterfaceModel interfaceTypeModel)
+                        var attributeGroup = AttributeGroups[attributeGroupRef.RefName];
+                        var attributes = attributeGroup.Attributes.Cast<XmlSchemaObject>()
+                            .Where(a => !(a is XmlSchemaAttributeGroupRef agr && agr.RefName == attributeGroupRef.RefName))
+                            .ToList();
+
+                        if (attributeGroup.RedefinedAttributeGroup != null)
                         {
-                            var interfaceProperty = interfaceTypeModel.Properties.Single(p => p.XmlSchemaName == attribute.QualifiedName);
-                            attributeQualifiedName = interfaceProperty.Type.XmlSchemaName;
-                            name = interfaceProperty.Name;
-                        }
-                        else
-                        {
-                            if (attributeQualifiedName.IsEmpty)
+                            foreach (var attr in attributeGroup.RedefinedAttributeGroup.Attributes.Cast<XmlSchemaObject>())
                             {
-                                attributeQualifiedName = attribute.QualifiedName;
+                                var n = attr.GetQualifiedName();
 
-                                if (attributeQualifiedName.IsEmpty || string.IsNullOrEmpty(attributeQualifiedName.Namespace))
-                                {
-                                    // inner type, have to generate a type name
-                                    var typeName = _configuration.NamingProvider.PropertyNameFromAttribute(owningTypeModel.Name, attribute.QualifiedName.Name, attribute);
-                                    attributeQualifiedName = new XmlQualifiedName(typeName, owningTypeModel.XmlSchemaName.Namespace);
-                                    // try to avoid name clashes
-                                    if (NameExists(attributeQualifiedName))
-                                    {
-                                        attributeQualifiedName = new[] { "Item", "Property", "Element" }
-                                            .Select(s => new XmlQualifiedName(attributeQualifiedName.Name + s, attributeQualifiedName.Namespace))
-                                            .First(n => !NameExists(n));
-                                    }
-                                }
-                            }
+                                if (n != null)
+                                    attributes.RemoveAll(a => a.GetQualifiedName() == n);
 
-                            if (name == owningTypeModel.Name)
-                            {
-                                name += "Property"; // member names cannot be the same as their enclosing type
+                                attributes.Add(attr);
                             }
                         }
 
-                        name = owningTypeModel.GetUniquePropertyName(name);
-
-                        var typeModel = CreateTypeModel(attributeQualifiedName, attribute.AttributeSchemaType);
-                        var property = new PropertyModel(_configuration, name, typeModel, owningTypeModel)
-                        {
-                            IsAttribute = true,
-                            IsRequired = attribute.Use == XmlSchemaUse.Required
-                        };
-
-                        property.SetFromNode(originalName, () => attribute.Use != XmlSchemaUse.Optional, attribute);
-                        property.SetSchemaNameAndNamespace(owningTypeModel, attribute);
-                        property.Documentation.AddRange(GetDocumentation(attribute));
-
-                        properties.Add(property);
-                    }
-                }
-                else if (item is XmlSchemaAttributeGroupRef attributeGroupRef)
-                {
-                    if (_configuration.GenerateInterfaces)
-                    {
-                        CreateTypeModel(attributeGroupRef.RefName, AttributeGroups[attributeGroupRef.RefName]);
-                    }
-
-                    var attributeGroup = AttributeGroups[attributeGroupRef.RefName];
-                    var attributes = attributeGroup.Attributes.Cast<XmlSchemaObject>()
-                        .Where(a => !(a is XmlSchemaAttributeGroupRef agr && agr.RefName == attributeGroupRef.RefName))
-                        .ToList();
-
-                    if (attributeGroup.RedefinedAttributeGroup != null)
-                    {
-                        foreach (var attr in attributeGroup.RedefinedAttributeGroup.Attributes.Cast<XmlSchemaObject>())
-                        {
-                            var n = attr.GetQualifiedName();
-
-                            if (n != null)
-                            {
-                                attributes.RemoveAll(a => a.GetQualifiedName() == n);
-                            }
-
-                            attributes.Add(attr);
-                        }
-                    }
-
-                    var groupProperties = CreatePropertiesForAttributes(source, owningTypeModel, attributes);
-                    properties.AddRange(groupProperties);
+                        properties.AddRange(CreatePropertiesForAttributes(source, owningTypeModel, attributes));
+                        break;
                 }
             }
-
             return properties;
+        }
+
+        private PropertyModel PropertyFromAttribute(TypeModel owningTypeModel, XmlSchemaAttributeEx attribute)
+        {
+            var attributeQualifiedName = attribute.AttributeSchemaType.QualifiedName;
+            var name = _configuration.NamingProvider.AttributeNameFromQualifiedName(attribute.QualifiedName, attribute);
+            var originalName = name;
+
+            if (attribute.Base.Parent is XmlSchemaAttributeGroup attributeGroup
+                && attributeGroup.QualifiedName != owningTypeModel.XmlSchemaName
+                && Types.TryGetValue(BuildKey(attributeGroup, attributeGroup.QualifiedName), out var typeModelValue)
+                && typeModelValue is InterfaceModel interfaceTypeModel)
+            {
+                var interfaceProperty = interfaceTypeModel.Properties.Single(p => p.XmlSchemaName == attribute.QualifiedName);
+                attributeQualifiedName = interfaceProperty.Type.XmlSchemaName;
+                name = interfaceProperty.Name;
+            }
+            else
+            {
+                if (attributeQualifiedName.IsEmpty)
+                {
+                    attributeQualifiedName = attribute.QualifiedName;
+
+                    if (attributeQualifiedName.IsEmpty || string.IsNullOrEmpty(attributeQualifiedName.Namespace))
+                    {
+                        // inner type, have to generate a type name
+                        var typeName = _configuration.NamingProvider.PropertyNameFromAttribute(owningTypeModel.Name, attribute.QualifiedName.Name, attribute);
+                        attributeQualifiedName = new XmlQualifiedName(typeName, owningTypeModel.XmlSchemaName.Namespace);
+                        // try to avoid name clashes
+                        if (NameExists(attributeQualifiedName))
+                            attributeQualifiedName = new[] { "Item", "Property", "Element" }.Select(s => new XmlQualifiedName(attributeQualifiedName.Name + s, attributeQualifiedName.Namespace)).First(n => !NameExists(n));
+                    }
+                }
+
+                if (name == owningTypeModel.Name)
+                    name += "Property";
+            }
+
+            name = owningTypeModel.GetUniquePropertyName(name);
+
+            var typeModel = CreateTypeModel(attributeQualifiedName, attribute.AttributeSchemaType);
+            var property = new PropertyModel(_configuration, name, typeModel, owningTypeModel)
+            {
+                IsAttribute = true,
+                IsRequired = attribute.Use == XmlSchemaUse.Required
+            };
+
+            property.SetFromNode(originalName, () => attribute.Use != XmlSchemaUse.Optional, attribute);
+            property.SetSchemaNameAndNamespace(owningTypeModel, attribute);
+            property.Documentation.AddRange(GetDocumentation(attribute));
+
+            return property;
         }
 
         private IEnumerable<PropertyModel> CreatePropertiesForElements(Uri source, TypeModel owningTypeModel, Particle particle, IEnumerable<Particle> items,
             Substitute substitute = null, int order = 0)
         {
             var properties = new List<PropertyModel>();
-            var xmlParticle = particle.XmlParticle;
 
             foreach (var item in items)
             {
                 PropertyModel property = null;
 
-                // ElementSchemaType must be non-null. This is not the case when maxOccurs="0".
-                if (item.XmlParticle is XmlSchemaElement xs && xs.ElementSchemaType != null)
+                switch (item.XmlParticle)
                 {
-                    XmlSchemaElementEx element = xs;
-                    XmlSchemaElementEx effectiveElement = substitute?.Element ?? element;
-                    var name = _configuration.NamingProvider.ElementNameFromQualifiedName(effectiveElement.QualifiedName, effectiveElement);
-                    var originalName = name;
-                    if (name == owningTypeModel.Name)
-                        name += "Property"; // member names cannot be the same as their enclosing type
+                    // ElementSchemaType must be non-null. This is not the case when maxOccurs="0".
+                    case XmlSchemaElement element when element.ElementSchemaType != null:
+                        property = PropertyFromElement(owningTypeModel, element, particle, item, substitute);
+                        break;
+                    case XmlSchemaAny any:
+                        SimpleModel typeModel = new(_configuration)
+                        {
+                            ValueType = _configuration.UseXElementForAny ? typeof(XElement) : typeof(XmlElement),
+                            UseDataTypeAttribute = false
+                        };
+                        property = new PropertyModel(_configuration, "Any", typeModel, owningTypeModel) { IsAny = true };
+                        property.SetFromParticles(particle, item);
+                        break;
+                    case XmlSchemaGroupRef groupRef:
+                        var group = Groups[groupRef.RefName];
 
-                    name = owningTypeModel.GetUniquePropertyName(name);
+                        if (_configuration.GenerateInterfaces)
+                            CreateTypeModel(groupRef.RefName, group);
 
-                    var typeModel = substitute?.Type ?? CreateTypeModel(GetQualifiedName(owningTypeModel, xmlParticle, element), element.ElementSchemaType);
+                        var groupItems = GetElements(groupRef.Particle).ToList();
+                        var groupProperties = CreatePropertiesForElements(source, owningTypeModel, item, groupItems, order: order).ToList();
+                        if (_configuration.EmitOrder)
+                            order += groupProperties.Count;
 
-                    property = new PropertyModel(_configuration, name, typeModel, owningTypeModel) { IsNillable = element.IsNillable };
-                    property.SetFromParticles(particle, item);
-                    property.SetFromNode(originalName, () => item.MinOccurs >= 1.0m && item.XmlParent is not XmlSchemaChoice, element);
-                    property.SetSchemaNameAndNamespace(owningTypeModel, effectiveElement);
-
-                    if (property.IsArray && !_configuration.GenerateComplexTypesForCollections)
-                    {
-                        property.Type.Namespace.Types.Remove(property.Type.Name);
-                    }
-                }
-                else
-                {
-                    switch (item.XmlParticle)
-                    {
-                        case XmlSchemaAny any:
-                            SimpleModel typeModel = new(_configuration)
-                            {
-                                ValueType = _configuration.UseXElementForAny ? typeof(XElement) : typeof(XmlElement),
-                                UseDataTypeAttribute = false
-                            };
-                            property = new PropertyModel(_configuration, "Any", typeModel, owningTypeModel) { IsAny = true };
-                            property.SetFromParticles(particle, item);
-                            break;
-                        case XmlSchemaGroupRef groupRef:
-                            var group = Groups[groupRef.RefName];
-
-                            if (_configuration.GenerateInterfaces)
-                                CreateTypeModel(groupRef.RefName, group);
-
-                            var groupItems = GetElements(groupRef.Particle).ToList();
-                            var groupProperties = CreatePropertiesForElements(source, owningTypeModel, item, groupItems, order: order).ToList();
-                            if (_configuration.EmitOrder)
-                                order += groupProperties.Count;
-
-                            properties.AddRange(groupProperties);
-                            break;
-                    }
+                        properties.AddRange(groupProperties);
+                        break;
                 }
 
                 // Discard duplicate property names. This is most likely due to:
@@ -934,6 +932,30 @@ namespace XmlSchemaClassGenerator
             return properties;
         }
 
+        private PropertyModel PropertyFromElement(TypeModel owningTypeModel, XmlSchemaElementEx element, Particle particle, Particle item, Substitute substitute)
+        {
+            PropertyModel property;
+            XmlSchemaElementEx effectiveElement = substitute?.Element ?? element;
+            var name = _configuration.NamingProvider.ElementNameFromQualifiedName(effectiveElement.QualifiedName, effectiveElement);
+            var originalName = name;
+            if (name == owningTypeModel.Name)
+                name += "Property"; // member names cannot be the same as their enclosing type
+
+            name = owningTypeModel.GetUniquePropertyName(name);
+
+            var typeModel = substitute?.Type ?? CreateTypeModel(GetQualifiedName(owningTypeModel, particle.XmlParticle, element), element.ElementSchemaType);
+
+            property = new PropertyModel(_configuration, name, typeModel, owningTypeModel) { IsNillable = element.IsNillable };
+            property.SetFromParticles(particle, item);
+            property.SetFromNode(originalName, () => item.MinOccurs >= 1.0m && item.XmlParent is not XmlSchemaChoice, element);
+            property.SetSchemaNameAndNamespace(owningTypeModel, effectiveElement);
+
+            if (property.IsArray && !_configuration.GenerateComplexTypesForCollections)
+                property.Type.Namespace.Types.Remove(property.Type.Name);
+
+            return property;
+        }
+
         private XmlQualifiedName GetQualifiedName(TypeModel typeModel, XmlSchemaParticle xmlParticle, XmlSchemaElementEx element)
         {
             var elementQualifiedName = element.ElementSchemaType.QualifiedName;
@@ -950,11 +972,7 @@ namespace XmlSchemaClassGenerator
                     elementQualifiedName = new XmlQualifiedName(typeName, typeModel.XmlSchemaName.Namespace);
                     // try to avoid name clashes
                     if (NameExists(elementQualifiedName))
-                    {
-                        elementQualifiedName = new[] { "Item", "Property", "Element" }
-                            .Select(s => new XmlQualifiedName(elementQualifiedName.Name + s, elementQualifiedName.Namespace))
-                            .First(n => !NameExists(n));
-                    }
+                        elementQualifiedName = new[] { "Item", "Property", "Element" }.Select(s => new XmlQualifiedName(elementQualifiedName.Name + s, elementQualifiedName.Namespace)).First(n => !NameExists(n));
                 }
             }
 
@@ -982,56 +1000,6 @@ namespace XmlSchemaClassGenerator
             var elements = _set.GlobalElements.Names.Cast<XmlQualifiedName>();
             var types = _set.GlobalTypes.Names.Cast<XmlQualifiedName>();
             return elements.Concat(types).Any(n => n.Namespace == name.Namespace && name.Name.Equals(n.Name, StringComparison.OrdinalIgnoreCase));
-        }
-
-        private IEnumerable<RestrictionModel> GetRestrictions(IEnumerable<XmlSchemaFacet> facets, XmlSchemaSimpleType type)
-        {
-            var min = facets.OfType<XmlSchemaMinLengthFacet>().Select(f => int.Parse(f.Value)).DefaultIfEmpty().Max();
-            var max = facets.OfType<XmlSchemaMaxLengthFacet>().Select(f => int.Parse(f.Value)).DefaultIfEmpty().Min();
-
-            if (_configuration.DataAnnotationMode == DataAnnotationMode.All)
-            {
-                if (min > 0) yield return new MinLengthRestrictionModel(_configuration) { Value = min };
-                if (max > 0) yield return new MaxLengthRestrictionModel(_configuration) { Value = max };
-            }
-            else if (min > 0 || max > 0)
-            {
-                yield return new MinMaxLengthRestrictionModel(_configuration) { Min = min, Max = max };
-            }
-
-            foreach (var facet in facets)
-            {
-                var valueType = type.Datatype.ValueType;
-                switch (facet)
-                {
-                    case XmlSchemaLengthFacet:
-                        var value = int.Parse(facet.Value);
-                        if (_configuration.DataAnnotationMode == DataAnnotationMode.All)
-                        {
-                            yield return new MinLengthRestrictionModel(_configuration) { Value = value };
-                            yield return new MaxLengthRestrictionModel(_configuration) { Value = value };
-                        }
-                        else
-                        {
-                            yield return new MinMaxLengthRestrictionModel(_configuration) { Min = value, Max = value };
-                        }
-                        break;
-                    case XmlSchemaTotalDigitsFacet:
-                        yield return new TotalDigitsRestrictionModel(_configuration) { Value = int.Parse(facet.Value) }; break;
-                    case XmlSchemaFractionDigitsFacet:
-                        yield return new FractionDigitsRestrictionModel(_configuration) { Value = int.Parse(facet.Value) }; break;
-                    case XmlSchemaPatternFacet:
-                        yield return new PatternRestrictionModel(_configuration) { Value = facet.Value }; break;
-                    case XmlSchemaMinInclusiveFacet:
-                        yield return new MinInclusiveRestrictionModel(_configuration) { Value = facet.Value, Type = valueType }; break;
-                    case XmlSchemaMinExclusiveFacet:
-                        yield return new MinExclusiveRestrictionModel(_configuration) { Value = facet.Value, Type = valueType }; break;
-                    case XmlSchemaMaxInclusiveFacet:
-                        yield return new MaxInclusiveRestrictionModel(_configuration) { Value = facet.Value, Type = valueType }; break;
-                    case XmlSchemaMaxExclusiveFacet:
-                        yield return new MaxExclusiveRestrictionModel(_configuration) { Value = facet.Value, Type = valueType }; break;
-                }
-            }
         }
 
         public IEnumerable<Particle> GetElements(XmlSchemaGroupBase groupBase)

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -149,14 +149,9 @@ namespace XmlSchemaClassGenerator
 
     public class InterfaceModel : ReferenceTypeModel
     {
-        public InterfaceModel(GeneratorConfiguration configuration)
-            : base(configuration)
-        {
-            Properties = new List<PropertyModel>();
-            DerivedTypes = new List<ReferenceTypeModel>();
-        }
+        public InterfaceModel(GeneratorConfiguration configuration) : base(configuration) { }
 
-        public List<ReferenceTypeModel> DerivedTypes { get; set; }
+        public List<ReferenceTypeModel> DerivedTypes { get; } = new();
 
         public override CodeTypeDeclaration Generate()
         {
@@ -219,14 +214,10 @@ namespace XmlSchemaClassGenerator
         public bool IsMixed { get; set; }
         public bool IsSubstitution { get; set; }
         public TypeModel BaseClass { get; set; }
-        public List<ClassModel> DerivedTypes { get; set; }
+        public List<ClassModel> DerivedTypes { get; set; } = new();
         public override bool IsSubtype => BaseClass != null;
 
-        public ClassModel(GeneratorConfiguration configuration)
-            : base(configuration)
-        {
-            DerivedTypes = new List<ClassModel>();
-        }
+        public ClassModel(GeneratorConfiguration configuration) : base(configuration) { }
 
         public IEnumerable<ClassModel> AllBaseClasses
         {
@@ -476,15 +467,10 @@ namespace XmlSchemaClassGenerator
 
     public class ReferenceTypeModel : TypeModel
     {
-        public ReferenceTypeModel(GeneratorConfiguration configuration)
-            : base(configuration)
-        {
-            Properties = new List<PropertyModel>();
-            Interfaces = new List<InterfaceModel>();
-        }
+        public ReferenceTypeModel(GeneratorConfiguration configuration) : base(configuration) { }
 
-        public List<PropertyModel> Properties { get; set; }
-        public List<InterfaceModel> Interfaces { get; }
+        public List<PropertyModel> Properties { get; } = new();
+        public List<InterfaceModel> Interfaces { get; } = new();
 
         public void AddInterfaces(IEnumerable<InterfaceModel> interfaces)
         {

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -279,16 +279,13 @@ namespace XmlSchemaClassGenerator
                 };
                 classDeclaration.Members.Add(propertyChangedEvent);
 
-                var propertyChangedModel = new PropertyModel(Configuration)
-                {
-                    Name = propertyChangedEvent.Name,
-                    OwningType = this,
-                    Type = new SimpleModel(Configuration) { ValueType = typeof(PropertyChangedEventHandler) }
-                };
+                SimpleModel type = new(Configuration) { ValueType = typeof(PropertyChangedEventHandler) };
+                var propertyChangedModel = new PropertyModel(Configuration, propertyChangedEvent.Name, type, this);
 
                 Configuration.MemberVisitor(propertyChangedEvent, propertyChangedModel);
 
-                var param = new CodeParameterDeclarationExpression(typeof(string), "propertyName");
+                var param = new CodeParameterDeclarationExpression(typeof(string), "propertyName = null");
+                param.CustomAttributes.Add(new(TypeRef<System.Runtime.CompilerServices.CallerMemberNameAttribute>()));
                 var threadSafeDelegateInvokeExpression = new CodeSnippetExpression($"{propertyChangedEvent.Name}?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs({param.Name}))");
                 var onPropChangedMethod = new CodeMemberMethod
                 {
@@ -309,27 +306,24 @@ namespace XmlSchemaClassGenerator
                 }
                 else if (!string.IsNullOrEmpty(Configuration.TextValuePropertyName))
                 {
+                    var textName = Configuration.TextValuePropertyName;
+                    var enableDataBinding = Configuration.EnableDataBinding;
                     var typeReference = BaseClass.GetReferenceFor(Namespace);
 
-                    var member = new CodeMemberField(typeReference, Configuration.TextValuePropertyName)
+                    CodeMemberField backingFieldMember = null;
+                    if (enableDataBinding)
                     {
-                        Attributes = MemberAttributes.Public,
-                    };
-
-                    if (Configuration.EnableDataBinding)
-                    {
-                        var backingFieldMember = new CodeMemberField(typeReference, member.Name.ToBackingField(Configuration.PrivateMemberPrefix))
+                        backingFieldMember = new CodeMemberField(typeReference, textName.ToBackingField(Configuration.PrivateMemberPrefix))
                         {
                             Attributes = MemberAttributes.Private
                         };
-                        member.Name += PropertyModel.GetAccessors(member.Name, backingFieldMember.Name, BaseClass.GetPropertyValueTypeCode(), false);
                         classDeclaration.Members.Add(backingFieldMember);
                     }
-                    else
+
+                    CodeMemberField text = new(typeReference, textName + PropertyModel.GetAccessors(backingFieldMember, enableDataBinding, BaseClass.GetPropertyValueTypeCode()))
                     {
-                        // hack to generate automatic property
-                        member.Name += GetSet;
-                    }
+                        Attributes = MemberAttributes.Public,
+                    };
 
                     var docs = new List<DocumentationModel> {
                         new() { Language = English, Text = "Gets or sets the text value." },
@@ -341,25 +335,20 @@ namespace XmlSchemaClassGenerator
                     if (BaseClass is SimpleModel simpleModel)
                     {
                         docs.AddRange(simpleModel.Restrictions.Select(r => new DocumentationModel { Language = English, Text = r.Description }));
-                        member.CustomAttributes.AddRange(simpleModel.GetRestrictionAttributes().ToArray());
+                        text.CustomAttributes.AddRange(simpleModel.GetRestrictionAttributes().ToArray());
 
                         if (BaseClass.GetQualifiedName() is { Namespace: XmlSchema.Namespace, Name: var name } && (simpleModel.XmlSchemaType.Datatype.IsDataTypeAttributeAllowed() ?? simpleModel.UseDataTypeAttribute))
                             attribute.Arguments.Add(new CodeAttributeArgument(nameof(XmlTextAttribute.DataType), new CodePrimitiveExpression(name)));
                     }
 
-                    member.Comments.AddRange(GetComments(docs).ToArray());
+                    text.Comments.AddRange(GetComments(docs).ToArray());
 
-                    member.CustomAttributes.Add(attribute);
-                    classDeclaration.Members.Add(member);
+                    text.CustomAttributes.Add(attribute);
+                    classDeclaration.Members.Add(text);
 
-                    var valuePropertyModel = new PropertyModel(Configuration)
-                    {
-                        Name = Configuration.TextValuePropertyName,
-                        OwningType = this,
-                        Type = BaseClass
-                    };
+                    var valuePropertyModel = new PropertyModel(Configuration, textName, BaseClass, this);
 
-                    Configuration.MemberVisitor(member, valuePropertyModel);
+                    Configuration.MemberVisitor(text, valuePropertyModel);
                 }
             }
 
@@ -376,11 +365,8 @@ namespace XmlSchemaClassGenerator
 
                 if (keyProperty == null)
                 {
-                    keyProperty = new PropertyModel(Configuration)
+                    keyProperty = new PropertyModel(Configuration, "Id", new SimpleModel(Configuration) { ValueType = typeof(long) }, this)
                     {
-                        Name = "Id",
-                        Type = new SimpleModel(Configuration) { ValueType = typeof(long) },
-                        OwningType = this,
                         Documentation = {
                             new() { Language = English, Text = "Gets or sets a value uniquely identifying this entity." },
                             new() { Language = German, Text = "Ruft einen Wert ab, der diese Entität eindeutig identifiziert, oder legt diesen fest." }
@@ -415,20 +401,12 @@ namespace XmlSchemaClassGenerator
                 {
                     propName = $"Text_{propertyIndex}";
                 }
-                var text = new CodeMemberField(typeof(string[]), propName);
                 // hack to generate automatic property
-                text.Name += GetSet;
-                text.Attributes = MemberAttributes.Public;
-                var xmlTextAttribute = AttributeDecl<XmlTextAttribute>();
-                text.CustomAttributes.Add(xmlTextAttribute);
+                var text = new CodeMemberField(typeof(string[]), propName + PropertyModel.GetAccessors()) { Attributes = MemberAttributes.Public };
+                text.CustomAttributes.Add(AttributeDecl<XmlTextAttribute>());
                 classDeclaration.Members.Add(text);
 
-                var textPropertyModel = new PropertyModel(Configuration)
-                {
-                    Name = propName,
-                    OwningType = this,
-                    Type = new SimpleModel(Configuration) { ValueType = typeof(string) }
-                };
+                var textPropertyModel = new PropertyModel(Configuration, propName, new SimpleModel(Configuration) { ValueType = typeof(string) }, this);
 
                 Configuration.MemberVisitor(text, textPropertyModel);
             }
@@ -528,65 +506,104 @@ namespace XmlSchemaClassGenerator
         private const string Specified = nameof(Specified);
         private const string Namespace = nameof(XmlRootAttribute.Namespace);
 
-        public TypeModel OwningType { get; set; }
-        public string Name { get; set; }
-        public string OriginalPropertyName { get; set; }
+        // ctor
+        public List<DocumentationModel> Documentation { get; } = new();
+        public List<Substitute> Substitutes { get; } = new();
+        public TypeModel OwningType { get; }
+        public TypeModel Type { get; }
+        public string Name { get; set; } // Only set when renaming interfaces.
+
+        // private
+        public string OriginalPropertyName { get; private set; }
+        public string DefaultValue { get; private set; }
+        public string FixedValue { get; private set; }
+        public XmlSchemaForm Form { get; private set; }
+        public string XmlNamespace { get; private set; }
+        public XmlQualifiedName XmlSchemaName { get; private set; }
+        public XmlSchemaParticle XmlParticle { get; private set; }
+        public XmlSchemaObject XmlParent { get; private set; }
+        public Particle Particle { get; private set; }
+
+        // public
         public bool IsAttribute { get; set; }
-        public TypeModel Type { get; set; }
-        public bool IsNullable { get; set; }
+        public bool IsRequired { get; set; }
         public bool IsNillable { get; set; }
         public bool IsCollection { get; set; }
-        public string DefaultValue { get; set; }
-        public string FixedValue { get; set; }
-        public XmlSchemaForm Form { get; set; }
-        public string XmlNamespace { get; set; }
-        public List<DocumentationModel> Documentation { get; }
         public bool IsDeprecated { get; set; }
-        public XmlQualifiedName XmlSchemaName { get; set; }
         public bool IsAny { get; set; }
         public int? Order { get; set; }
         public bool IsKey { get; set; }
-        public XmlSchemaParticle XmlParticle { get; set; }
-        public XmlSchemaObject XmlParent { get; set; }
-        public Particle Particle { get; set; }
-        public List<Substitute> Substitutes { get; set; }
 
-        public PropertyModel(GeneratorConfiguration configuration) : base(configuration)
+        public PropertyModel(GeneratorConfiguration configuration, string name, TypeModel type, TypeModel owningType) : base(configuration)
         {
-            Documentation = new List<DocumentationModel>();
-            Substitutes = new List<Substitute>();
+            Name = name;
+            Type = type;
+            OwningType = owningType;
         }
 
-        internal static string GetAccessors(string memberName, string backingFieldName, PropertyValueTypeCode typeCode, bool privateSetter, bool withDataBinding = true)
+        public void SetFromNode(string originalName, Func<bool> useFixedIfNoDefault, IXmlSchemaNode xs)
         {
-            string assign = $@"
-                {backingFieldName} = value;";
+            OriginalPropertyName = originalName;
 
-            return CodeUtilities.NormalizeNewlines($@"
+            DefaultValue = xs.DefaultValue ?? (useFixedIfNoDefault() ? xs.FixedValue : null);
+            FixedValue = xs.FixedValue;
+            Form = xs.Form switch
+            {
+                XmlSchemaForm.None => xs.RefName?.IsEmpty == false ? XmlSchemaForm.Qualified : xs.FormDefault,
+                _ => xs.Form,
+            };
+        }
+
+        public void SetFromParticles(Particle particle, Particle item)
+        {
+            Particle = item;
+            XmlParticle = item.XmlParticle;
+            XmlParent = item.XmlParent;
+
+            IsRequired = item.MinOccurs >= 1.0m && (item.XmlParent is not XmlSchemaChoice);
+            IsCollection = item.MaxOccurs > 1.0m || particle.MaxOccurs > 1.0m; // http://msdn.microsoft.com/en-us/library/vstudio/d3hx2s7e(v=vs.100).aspx
+        }
+
+        public void SetSchemaNameAndNamespace(TypeModel owningTypeModel, IXmlSchemaNode xs)
+        {
+            XmlSchemaName = xs.QualifiedName;
+            XmlNamespace = string.IsNullOrEmpty(xs.QualifiedName.Namespace)
+                           || xs.QualifiedName.Namespace == owningTypeModel.XmlSchemaName.Namespace ? null
+                            : xs.QualifiedName.Namespace;
+        }
+
+        internal static string GetAccessors(CodeMemberField backingField = null, bool withDataBinding = false, PropertyValueTypeCode typeCode = PropertyValueTypeCode.Other, bool privateSetter = false)
+        {
+            return backingField == null ? " { get; set; }" : CodeUtilities.NormalizeNewlines($@"
         {{
             get
             {{
-                return {backingFieldName};
+                return {backingField.Name};
             }}
             {(privateSetter ? "private " : string.Empty)}set
             {{{(typeCode, withDataBinding) switch
             {
                 (PropertyValueTypeCode.ValueType, true) => $@"
-                if (!{backingFieldName}.Equals(value))
-                {{{assign}
-                    OnPropertyChanged(nameof({memberName}));
-                }}",
+                if ({checkEquality()}){assignAndNotify()}",
                 (PropertyValueTypeCode.Other or PropertyValueTypeCode.Array, true) => $@"
-                if ({backingFieldName} == value)
+                if ({backingField.Name} == value)
                     return;
-                if ({backingFieldName} == null || value == null || !{backingFieldName}.{(typeCode is PropertyValueTypeCode.Other ? EqualsMethod : nameof(Enumerable.SequenceEqual))}(value))
-                {{{assign}
-                    OnPropertyChanged(nameof({memberName}));
-                }}",
-                _ => assign,
+                if ({backingField.Name} == null || value == null || {checkEquality()}){assignAndNotify()}",
+                _ => assign(),
             }}
             }}
         }}");
+
+            string assign() => $@"
+                {backingField.Name} = value;";
+
+            string assignAndNotify() => $@"
+                {{{assign()}
+                    {OnPropertyChanged}();
+                }}";
+
+            string checkEquality()
+                => $"!{backingField.Name}.{(typeCode is PropertyValueTypeCode.Array ? nameof(Enumerable.SequenceEqual) : EqualsMethod)}(value)";
         }
 
         private ClassModel TypeClassModel => Type as ClassModel;
@@ -595,35 +612,31 @@ namespace XmlSchemaClassGenerator
         /// A property is an array if it is a sequence containing a single element with maxOccurs > 1.
         /// </summary>
         public bool IsArray => Configuration.UseArrayItemAttribute
-                && !IsCollection && !IsAttribute && !IsList && TypeClassModel != null
+                && !IsCollection && !IsList && TypeClassModel != null
                 && TypeClassModel.BaseClass == null
                 && TypeClassModel.Properties.Count == 1
                 && !TypeClassModel.Properties[0].IsAttribute && !TypeClassModel.Properties[0].IsAny
                 && TypeClassModel.Properties[0].IsCollection;
 
-        private bool IsEnumerable => IsCollection || IsArray;
+        private bool IsEnumerable => IsCollection || IsArray || IsList;
 
         private TypeModel PropertyType => !IsArray ? Type : TypeClassModel.Properties[0].Type;
 
-        private bool IsNullableValueType => DefaultValue == null
-                    && IsNullable && !IsEnumerable && !IsList
-                    && ((PropertyType is EnumModel) || (PropertyType is SimpleModel model && model.ValueType.IsValueType));
+        private bool IsNullable => DefaultValue == null && !IsRequired && !IsEnumerable;
 
-        private bool IsNullableReferenceType => DefaultValue == null
-                    && IsNullable && (IsEnumerable || IsList || PropertyType is ClassModel || (PropertyType is SimpleModel model && !model.ValueType.IsValueType));
+        private bool IsValueType => PropertyType is EnumModel || (PropertyType is SimpleModel model && model.ValueType.IsValueType);
 
-        private bool IsNillableValueType => IsNillable
-                    && !IsEnumerable
-                    && ((PropertyType is EnumModel) || (PropertyType is SimpleModel model && model.ValueType.IsValueType));
+        private bool IsNullableValueType => IsNullable && IsValueType;
+
+        private bool IsNullableReferenceType => IsNullable && (PropertyType is ClassModel || (PropertyType is SimpleModel model && !model.ValueType.IsValueType));
+
+        private bool IsNillableValueType => IsNillable && !IsEnumerable && IsValueType;
 
         private bool IsList => Type.XmlSchemaType?.Datatype?.Variety == XmlSchemaDatatypeVariety.List;
 
-        private bool IsPrivateSetter => Configuration.CollectionSettersMode == CollectionSettersMode.Private
-                    && (IsEnumerable || (IsList && IsAttribute));
+        private bool IsPrivateSetter => IsEnumerable && Configuration.CollectionSettersMode == CollectionSettersMode.Private;
 
-        private CodeTypeReference TypeReference => PropertyType.GetReferenceFor(OwningType.Namespace,
-                    collection: IsEnumerable || (IsList && IsAttribute),
-                    attribute: IsAttribute);
+        private CodeTypeReference TypeReference => PropertyType.GetReferenceFor(OwningType.Namespace, collection: IsEnumerable, attribute: IsAttribute);
 
         private void AddDocs(CodeTypeMember member)
         {
@@ -672,7 +685,7 @@ namespace XmlSchemaClassGenerator
                 HasSet = !isPrivateSetter
             };
 
-            if (DefaultValue != null && IsNullable)
+            if (DefaultValue != null && !IsRequired)
             {
                 var defaultValueExpression = propertyType.GetDefaultValueFor(DefaultValue, IsAttribute);
 
@@ -694,13 +707,10 @@ namespace XmlSchemaClassGenerator
             // Note: We use CodeMemberField because CodeMemberProperty doesn't allow for private set
             var member = new CodeMemberField() { Name = Name };
 
-            var typeClassModel = TypeClassModel;
             var isArray = IsArray;
             var isEnumerable = IsEnumerable;
             var propertyType = PropertyType;
             var isNullableValueType = IsNullableValueType;
-            var isNullableReferenceType = IsNullableReferenceType;
-            var isPrivateSetter = IsPrivateSetter;
             var typeReference = TypeReference;
 
             CodeAttributeDeclaration ignoreAttribute = new(TypeRef<XmlIgnoreAttribute>());
@@ -716,7 +726,7 @@ namespace XmlSchemaClassGenerator
                 typeDeclaration.Members.Add(backingField);
             }
 
-            if (DefaultValue == null || ((isEnumerable || (IsList && IsAttribute)) && IsNullable))
+            if (DefaultValue == null || (isEnumerable && !IsRequired))
             {
                 if (isNullableValueType && Configuration.GenerateNullables && !(Configuration.UseShouldSerializePattern && !IsAttribute))
                     member.Name += Value;
@@ -742,9 +752,8 @@ namespace XmlSchemaClassGenerator
                     member.Type = typeReference;
                 }
 
-                member.Name += backingField != null
-                    ? GetAccessors(member.Name, backingField.Name, isEnumerable ? PropertyValueTypeCode.Array : propertyType.GetPropertyValueTypeCode(), isPrivateSetter, withDataBinding)
-                    : $" {{ get; {(isPrivateSetter ? "private " : string.Empty)}set; }}"; // hack to generate automatic property
+                var propertyValueTypeCode = IsCollection || isArray ? PropertyValueTypeCode.Array : propertyType.GetPropertyValueTypeCode();
+                member.Name += GetAccessors(backingField, withDataBinding, propertyValueTypeCode, IsPrivateSetter);
             }
             else
             {
@@ -753,9 +762,9 @@ namespace XmlSchemaClassGenerator
 
                 member.Type = IsNillableValueType ? NullableTypeRef(typeReference) : typeReference;
 
-                member.Name += GetAccessors(member.Name, backingField.Name, propertyType.GetPropertyValueTypeCode(), false, withDataBinding);
+                member.Name += GetAccessors(backingField, withDataBinding, propertyType.GetPropertyValueTypeCode());
 
-                if (IsNullable && (defaultValueExpression is CodePrimitiveExpression or CodeFieldReferenceExpression) && !CodeUtilities.IsXmlLangOrSpace(XmlSchemaName))
+                if (!IsRequired && (defaultValueExpression is CodePrimitiveExpression or CodeFieldReferenceExpression) && !CodeUtilities.IsXmlLangOrSpace(XmlSchemaName))
                     member.CustomAttributes.Add(CreateDefaultValueAttribute(typeReference, defaultValueExpression));
             }
 
@@ -764,7 +773,7 @@ namespace XmlSchemaClassGenerator
 
             AddDocs(member);
 
-            if (!IsNullable && Configuration.DataAnnotationMode != DataAnnotationMode.None)
+            if (IsRequired && Configuration.DataAnnotationMode != DataAnnotationMode.None)
             {
                 var requiredAttribute = new CodeAttributeDeclaration(CodeUtilities.CreateTypeReference(Attributes.Required, Configuration));
                 member.CustomAttributes.Add(requiredAttribute);
@@ -790,7 +799,7 @@ namespace XmlSchemaClassGenerator
                 CodeMemberField specifiedMember = null;
                 if (generateSpecifiedProperty)
                 {
-                    specifiedMember = new CodeMemberField(typeof(bool), specifiedName + Specified + GetSet);
+                    specifiedMember = new CodeMemberField(typeof(bool), specifiedName + Specified + GetAccessors());
                     specifiedMember.CustomAttributes.Add(ignoreAttribute);
                     if (Configuration.EntityFramework && generateNullablesProperty) { specifiedMember.CustomAttributes.Add(notMappedAttribute); }
                     specifiedMember.Attributes = MemberAttributes.Public;
@@ -801,7 +810,7 @@ namespace XmlSchemaClassGenerator
                     specifiedMember.Comments.AddRange(GetComments(specifiedDocs).ToArray());
                     typeDeclaration.Members.Add(specifiedMember);
 
-                    var specifiedMemberPropertyModel = new PropertyModel(Configuration) { Name = specifiedName + Specified };
+                    var specifiedMemberPropertyModel = new PropertyModel(Configuration, specifiedName + Specified, null, null);
 
                     Configuration.MemberVisitor(specifiedMember, specifiedMemberPropertyModel);
                 }
@@ -874,7 +883,7 @@ namespace XmlSchemaClassGenerator
                     Configuration.MemberVisitor(nullableMember, this);
                 }
             }
-            else if ((isEnumerable || (IsList && IsAttribute)) && IsNullable)
+            else if (isEnumerable && !IsRequired)
             {
                 var specifiedProperty = new CodeMemberProperty
                 {
@@ -911,7 +920,7 @@ namespace XmlSchemaClassGenerator
                 typeDeclaration.Members.Add(specifiedProperty);
             }
 
-            if (!IsEnumerable && isNullableReferenceType && Configuration.EnableNullableReferenceAttributes)
+            if (IsNullableReferenceType && Configuration.EnableNullableReferenceAttributes)
             {
                 member.CustomAttributes.Add(new CodeAttributeDeclaration(CodeUtilities.CreateTypeReference(Attributes.AllowNull, Configuration)));
                 member.CustomAttributes.Add(new CodeAttributeDeclaration(CodeUtilities.CreateTypeReference(Attributes.MaybeNull, Configuration)));
@@ -921,7 +930,7 @@ namespace XmlSchemaClassGenerator
             member.CustomAttributes.AddRange(attributes);
 
             // initialize List<>
-            if ((isEnumerable || (IsList && IsAttribute)) && Configuration.CollectionSettersMode != CollectionSettersMode.PublicWithoutConstructorInitialization)
+            if (isEnumerable && Configuration.CollectionSettersMode != CollectionSettersMode.PublicWithoutConstructorInitialization)
             {
                 var constructor = typeDeclaration.Members.OfType<CodeConstructor>().FirstOrDefault();
 
@@ -959,7 +968,7 @@ namespace XmlSchemaClassGenerator
 
             if (isArray)
             {
-                var arrayItemProperty = typeClassModel.Properties[0];
+                var arrayItemProperty = TypeClassModel.Properties[0];
 
                 // HACK: repackage as ArrayItemAttribute
                 foreach (var propertyAttribute in arrayItemProperty.GetAttributes(false, OwningType).ToList())
@@ -1070,7 +1079,7 @@ namespace XmlSchemaClassGenerator
                     }
                 }
 
-                if (IsNillable && !(IsCollection && Type is SimpleModel m && m.ValueType.IsValueType) && !(IsNullable && Configuration.DoNotForceIsNullable))
+                if (IsNillable && !(IsCollection && Type is SimpleModel m && m.ValueType.IsValueType) && (IsRequired || !Configuration.DoNotForceIsNullable))
                     args.Add(new("IsNullable", new CodePrimitiveExpression(true)));
 
                 if (Type is SimpleModel simpleModel && simpleModel.UseDataTypeAttribute)
@@ -1235,21 +1244,9 @@ namespace XmlSchemaClassGenerator
             {
                 var collectionType = forInit ? (Configuration.CollectionImplementationType ?? Configuration.CollectionType) : Configuration.CollectionType;
 
-                if (collectionType.IsGenericType)
-                {
-                    type = collectionType.MakeGenericType(type);
-                }
-                else
-                {
-                    if (collectionType == typeof(Array))
-                    {
-                        type = type.MakeArrayType();
-                    }
-                    else
-                    {
-                        type = collectionType;
-                    }
-                }
+                type = collectionType.IsGenericType ? collectionType.MakeGenericType(type)
+                     : collectionType == typeof(Array) ? type.MakeArrayType()
+                     : collectionType;
             }
 
             return CodeUtilities.CreateTypeReference(type, Configuration);
@@ -1352,8 +1349,6 @@ namespace XmlSchemaClassGenerator
         protected const string OnPropertyChanged = nameof(OnPropertyChanged);
         protected const string EqualsMethod = nameof(object.Equals);
         protected const string HasValue = nameof(Nullable<int>.HasValue);
-
-        protected const string GetSet = " { get; set; }";
 
         protected const string English = "en";
         protected const string German = "de";


### PR DESCRIPTION
When applying the latest release to our project, all of the NRT warnings were fixed except one. The difference for this is one was that the complex type was referenced rather than inline, and just changing that has removed the nullable attributes, however since it is also never null in the initial state, I thought this change should be made. There's no rush to complete this, and I think it may need some more thought.

Combine `IsCollection`, `IsArray` and `IsList` into `IsEnumerable`, and use for nullable attribute prevention.
Moved `GetSet` into `GetAccessors` to avoid nested ternary
Tidied up `ModelBuilder` by encapsulating common groups of property setters on `PropertyModel`, using `IXmlSchemaNode`.