### PR TITLE
fix interface for attributeGroup

### DIFF
--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -549,7 +549,7 @@ namespace XmlSchemaClassGenerator
                     classModel.Properties.AddRange(attributeProperties);
 
                     if (_configuration.GenerateInterfaces)
-                        AddInterfaces(classModel, items);
+                        AddInterfaces(classModel, attributes);
                 }
 
                 XmlSchemaAnyAttribute anyAttribute = null;


### PR DESCRIPTION
Starting from v2.0.711 Interfaces are not more implemented in generated code
