### PR TITLE
Implemented option to treat enumeration as string instead of creating enum

### DIFF
--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -57,6 +57,7 @@ namespace XmlSchemaClassGenerator.Console
             var nullableReferenceAttributes = false;
             var generateCommandLineArgs = true;
             var useArrayItemAttribute = true;
+            var enumAsString = false;
             var namespaceFiles = new List<string>();
 
             var options = new OptionSet {
@@ -135,6 +136,7 @@ without backing field initialization for collections
                 { "nc|netCore", "generate .NET Core specific code that might not work with .NET Framework (default is false)", v => netCoreSpecificCode = v != null },
                 { "nr|nullableReferenceAttributes", "generate attributes for nullable reference types (default is false)", v => nullableReferenceAttributes = v != null },
                 { "ar|useArrayItemAttribute", "use ArrayItemAttribute for sequences with single elements (default is true)", v => useArrayItemAttribute = v != null },
+                { "es|enumAsString", "Use string instead of enum for enumeration", v => enumAsString = v != null },
                 { "ca|commandArgs", "generate a comment with the exact command line arguments that were used to generate the source code (default is true)", v => generateCommandLineArgs = v != null },
             };
 
@@ -216,6 +218,7 @@ without backing field initialization for collections
                 EnableNullableReferenceAttributes = nullableReferenceAttributes,
                 GenerateCommandLineArgumentsComment = generateCommandLineArgs,
                 UseArrayItemAttribute = useArrayItemAttribute,
+                EnumAsString = enumAsString,
             };
 
             generator.CommentLanguages.AddRange(commentLanguages);

--- a/XmlSchemaClassGenerator.Tests/Compiler.cs
+++ b/XmlSchemaClassGenerator.Tests/Compiler.cs
@@ -116,6 +116,7 @@ namespace XmlSchemaClassGenerator.Tests
                 EnableNullableReferenceAttributes = generatorPrototype.EnableNullableReferenceAttributes,
                 NamingScheme = generatorPrototype.NamingScheme,
                 UseArrayItemAttribute = generatorPrototype.UseArrayItemAttribute,
+                EnumAsString = generatorPrototype.EnumAsString,
             };
 
             gen.CommentLanguages.Clear();

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -65,6 +65,7 @@ namespace XmlSchemaClassGenerator.Tests
                 CollectionImplementationType = generatorPrototype.CollectionImplementationType,
                 CollectionSettersMode = generatorPrototype.CollectionSettersMode,
                 UseArrayItemAttribute = generatorPrototype.UseArrayItemAttribute,
+                EnumAsString = generatorPrototype.EnumAsString,
             };
 
             gen.CommentLanguages.Clear();
@@ -973,6 +974,43 @@ namespace XmlSchemaClassGenerator.Tests
 
             Assert.Contains(@"public partial class MyType", generatedType);
             Assert.Contains(@"public enum MyType2", generatedType);
+        }
+
+        [Fact]
+        public void EnumAsStringOption()
+        {
+            const string xsd = @"<?xml version=""1.0"" encoding = ""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"" targetNamespace=""http://local.none"">
+	<xs:element name=""Authorisation"">
+		<xs:complexType>
+			<xs:sequence>
+				<xs:element name=""type"">
+					<xs:simpleType>
+						<xs:restriction base=""xs:string"">
+							<xs:enumeration value=""C019""/>
+							<xs:enumeration value=""C512""/>
+							<xs:enumeration value=""C513""/>
+							<xs:enumeration value=""C514""/>
+						</xs:restriction>
+					</xs:simpleType>
+				</xs:element>
+			</xs:sequence>
+		</xs:complexType>
+	</xs:element>
+</xs:schema>
+";
+            var generator = new Generator
+            {
+                NamespaceProvider = new NamespaceProvider
+                {
+                    GenerateNamespace = key => "Test"
+                },
+                EnumAsString = true
+            };
+
+            var generatedType = ConvertXml(nameof(EnumAsStringOption), xsd, generator).First();
+
+            Assert.Contains(@"public string Type", generatedType);
         }
 
         [Fact]

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -33,6 +33,12 @@ namespace XmlSchemaClassGenerator
             set { _configuration.OutputWriter = value; }
         }
 
+        public bool EnumAsString
+        {
+            get { return _configuration.EnumAsString; }
+            set { _configuration.EnumAsString = value; }
+        }
+
         public bool GenerateComplexTypesForCollections
         {
             get { return _configuration.GenerateComplexTypesForCollections; }

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -41,6 +41,8 @@ namespace XmlSchemaClassGenerator
             CommandLineArgumentsProvider = CommandLineArgumentsProvider.CreateFromEnvironment();
         }
 
+        public bool EnumAsString { get; set; }
+
         /// <summary>
         /// The writer to be used to generate the code files
         /// </summary>

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Xml;
 using System.Xml.Linq;
 using System.Xml.Schema;
+using System.Xml.Serialization;
 
 namespace XmlSchemaClassGenerator
 {
@@ -632,10 +633,10 @@ namespace XmlSchemaClassGenerator
                 if (facets.Count > 0)
                 {
                     var enumFacets = facets.OfType<XmlSchemaEnumerationFacet>().ToList();
-
+                    
                     // If a union has enum restrictions, there must be an enum restriction in all parts of the union
                     // If there are other restrictions mixed into the enumeration values, we'll generate a string to play it safe.
-                    if (enumFacets.Count > 0 && (baseFacets is null || baseFacets.All(fs => fs.OfType<XmlSchemaEnumerationFacet>().Any())))
+                    if (enumFacets.Count > 0 && (baseFacets is null || baseFacets.All(fs => fs.OfType<XmlSchemaEnumerationFacet>().Any())) && !_configuration.EnumAsString)
                         return CreateEnumModel(simpleType, enumFacets);
 
                     restrictions = GetRestrictions(facets, simpleType).Where(r => r != null).Sanitize().ToList();


### PR DESCRIPTION
Sometimes enums are not desirable and is more of a complication than help. In these cases it is nice to have an option to turn off enum creation and rather create the property as string.