### PR TITLE
In case a element which is defined as a sequence, has a default value,

### DIFF
--- a/XmlSchemaClassGenerator.Tests/DefaultInSequenceTests.cs
+++ b/XmlSchemaClassGenerator.Tests/DefaultInSequenceTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace XmlSchemaClassGenerator.Tests
+{
+	public class DefaultInSequenceTests
+	{
+		/// <summary>
+		/// In case a element which is defined as a sequence, has a default value,
+		/// the default value shall be ignored (it was wrong to initialize a collection with int value, for example).
+		/// bakcing field was like: private Collection<int> _someElementWithDefaultValue = 0;
+		/// In such case, the syntax breaks compliation.
+		/// We would like to verify the default is ignored.
+		/// </summary>
+		[Fact]
+		public void SequenceWithDefaultValue_CompilationPass()
+		{
+			var assembly = Compiler.Generate(nameof(SequenceWithDefaultValue_CompilationPass),
+				"xsd/SequenceWithDefault/*.xsd", new Generator
+				{
+					GenerateNullables = true,
+					UseShouldSerializePattern = true,
+					NamespaceProvider = new NamespaceProvider
+					{
+						GenerateNamespace = key => "Test"
+					}
+				});
+
+			var type = assembly.GetType("Test.SomeComplexType");
+
+			var collectionProperties = type
+				.GetProperties()
+				.Select(p => (p.Name, p.PropertyType))
+				.OrderBy(p => p.Name)
+				.ToArray();
+
+			Assert.Equal(new[]
+			{
+				("SomeElementWithDefault", typeof(Collection<int>)),
+			}, collectionProperties);
+		}
+	}
+}

--- a/XmlSchemaClassGenerator.Tests/xsd/SequenceWithDefault/SomeComplexType.xsd
+++ b/XmlSchemaClassGenerator.Tests/xsd/SequenceWithDefault/SomeComplexType.xsd
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<xs:schema id="default"
+    targetNamespace="http://tempuri.org/default.xsd"
+    elementFormDefault="qualified"
+    xmlns="http://tempuri.org/default.xsd"
+    xmlns:mstns="http://tempuri.org/default.xsd"
+    xmlns:xs="http://www.w3.org/2001/XMLSchema"
+>
+    <xs:complexType name="SomeComplexType">
+           <xs:sequence maxOccurs="unbounded" minOccurs="1">
+               <xs:element name="someElementWithDefault"  type="xs:int"  default="0"/>
+           </xs:sequence>
+    </xs:complexType>
+</xs:schema>

--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -716,7 +716,7 @@ namespace XmlSchemaClassGenerator
                 typeDeclaration.Members.Add(backingField);
             }
 
-            if (DefaultValue == null || (isEnumerable && !IsRequired))
+            if (DefaultValue == null || isEnumerable)
             {
                 if (isNullableValueType && Configuration.GenerateNullables && !(Configuration.UseShouldSerializePattern && !IsAttribute))
                     member.Name += Value;


### PR DESCRIPTION
the default value shall be ignored (it was wrong to initialize a collection with int value, for example). bakcing field was like: private Collection<int> _someElementWithDefaultValue = 0; In such case, the syntax breaks compliation.
We would like to verify the default value defined in the schema is ignored.