### PR TITLE
Add option for separate namespace hierarchy by folder

### DIFF
--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -63,6 +63,7 @@ namespace XmlSchemaClassGenerator.Console
             var namespaceFiles = new List<string>();
             var nameSubstituteFiles = new List<string>();
             var unionCommonType = false;
+            var separateNamespaceHierarchy = false;
 
             var options = new OptionSet {
                 { "h|help", "show this message and exit", v => showHelp = v != null },
@@ -138,6 +139,7 @@ without backing field initialization for collections
                 { "cc|complexTypesForCollections", "generate complex types for collections (default is true)", v => generateComplexTypesForCollections = v != null },
                 { "s|useShouldSerialize", "use ShouldSerialize pattern instead of Specified pattern (default is false)", v => useShouldSerialize = v != null },
                 { "sf|separateFiles", "generate a separate file for each class (default is false)", v => separateClasses = v != null },
+                { "nh|namespaceHierarchy", "generate a separate folder for namespace hierarchy. Accepted only if \"separateFiles\" is true (default is false)", v=> separateNamespaceHierarchy = v != null },
                 { "sg|separateSubstitutes", "generate a separate property for each element of a substitution group (default is false)", v => separateSubstitutes = v != null },
                 { "dnfin|doNotForceIsNullable", "do not force generator to emit IsNullable = true in XmlElement annotation for nillable elements when element is nullable (minOccurs < 1 or parent element is choice) (default is false)", v => doNotForceIsNullable = v != null },
                 { "cn|compactTypeNames", "use type names without namespace qualifier for types in the using list (default is false)", v => compactTypeNames = v != null },
@@ -235,7 +237,8 @@ without backing field initialization for collections
                 GenerateCommandLineArgumentsComment = generateCommandLineArgs,
                 UseArrayItemAttribute = useArrayItemAttribute,
                 EnumAsString = enumAsString,
-                MapUnionToWidestCommonType = unionCommonType
+                MapUnionToWidestCommonType = unionCommonType,
+                SeparateNamespaceHierarchy = separateNamespaceHierarchy
             };
 
             if (nameSubstituteMap.Any())

--- a/XmlSchemaClassGenerator.Tests/Compiler.cs
+++ b/XmlSchemaClassGenerator.Tests/Compiler.cs
@@ -117,7 +117,8 @@ namespace XmlSchemaClassGenerator.Tests
                 NamingScheme = generatorPrototype.NamingScheme,
                 UseArrayItemAttribute = generatorPrototype.UseArrayItemAttribute,
                 EnumAsString = generatorPrototype.EnumAsString,
-                MapUnionToWidestCommonType = generatorPrototype.MapUnionToWidestCommonType
+                MapUnionToWidestCommonType = generatorPrototype.MapUnionToWidestCommonType,
+                SeparateNamespaceHierarchy = generatorPrototype.SeparateNamespaceHierarchy
             };
 
             gen.CommentLanguages.Clear();

--- a/XmlSchemaClassGenerator.Tests/FileOutputWriterTests.cs
+++ b/XmlSchemaClassGenerator.Tests/FileOutputWriterTests.cs
@@ -312,6 +312,7 @@
                     EnableDataBinding = true,
                     SeparateClasses = true,
                     NamespacePrefix = "Generator.Prefix",
+                    SeparateNamespaceHierarchy = true,
                 });
 
             SharedTestFunctions.TestSamples(_output, "SeparateDefaultProviderGeneratorPrefix", PrefixPattern);
@@ -336,7 +337,7 @@
                     EnableDataBinding = true,
                     SeparateClasses = true,
                     NamespacePrefix = "Generator.Prefix",
-                    SeparateNamespaceHierarchy = true
+                    SeparateNamespaceHierarchy = true,
                 });
 
             SharedTestFunctions.TestSamples(_output, "SeparateWithNamespaceProviderGeneratorPrefix", PrefixPattern);

--- a/XmlSchemaClassGenerator.Tests/FileOutputWriterTests.cs
+++ b/XmlSchemaClassGenerator.Tests/FileOutputWriterTests.cs
@@ -322,6 +322,31 @@
         [Fact]
         [TestPriority(1)]
         [UseCulture("en-US")]
+        public void TestSeparateWithNamespaceProviderGeneratorPrefix()
+        {
+            var directory = Path.Combine("output", "FileOutputWriterTests", "SeparateWithNamespaceProviderGeneratorPrefix");
+            var outputWriter = new FileWatcherOutputWriter(directory);
+
+            Compiler.Generate(
+                "SeparateWithNamespaceProviderGeneratorPrefix",
+                PrefixPattern,
+                new Generator
+                {
+                    OutputWriter = outputWriter,
+                    EnableDataBinding = true,
+                    SeparateClasses = true,
+                    NamespacePrefix = "Generator.Prefix",
+                    SeparateNamespaceHierarchy = true
+                });
+
+            SharedTestFunctions.TestSamples(_output, "SeparateWithNamespaceProviderGeneratorPrefix", PrefixPattern);
+            Assert.Equal(2, outputWriter.Files.Count());
+            Assert.Equal(Path.Combine(directory, "Generator", "Prefix", "PurchaseOrderType.cs"), outputWriter.Files.First());
+        }
+
+        [Fact]
+        [TestPriority(1)]
+        [UseCulture("en-US")]
         public void TestSeparateEmptyKeyProvider()
         {
             var directory = Path.Combine("output", "FileOutputWriterTests", "SeparateEmptyKeyProvider");

--- a/XmlSchemaClassGenerator.Tests/FileOutputWriterTests.cs
+++ b/XmlSchemaClassGenerator.Tests/FileOutputWriterTests.cs
@@ -312,7 +312,7 @@
                     EnableDataBinding = true,
                     SeparateClasses = true,
                     NamespacePrefix = "Generator.Prefix",
-                    SeparateNamespaceHierarchy = true,
+                    SeparateNamespaceHierarchy = false,
                 });
 
             SharedTestFunctions.TestSamples(_output, "SeparateDefaultProviderGeneratorPrefix", PrefixPattern);

--- a/XmlSchemaClassGenerator/FileOutputWriter.cs
+++ b/XmlSchemaClassGenerator/FileOutputWriter.cs
@@ -68,9 +68,18 @@ namespace XmlSchemaClassGenerator
 
         private void WriteSeparateFiles(CodeNamespace cn)
         {
-            var dirPath = Path.Combine(OutputDirectory, ValidateName(cn.Name));
+            var validatedNamespaceName = ValidateName(cn.Name);
+
+            var namespacePath = validatedNamespaceName;
+            
+            if (Configuration?.SeparateNamespaceHierarchy == true)
+            {
+                namespacePath = Path.Combine(validatedNamespaceName.Split('.'));
+            }
+
+            var dirPath = Path.Combine(OutputDirectory, namespacePath);
             var ccu = new CodeCompileUnit();
-            var cns = new CodeNamespace(ValidateName(cn.Name));
+            var cns = new CodeNamespace(validatedNamespaceName);
 
             Directory.CreateDirectory(dirPath);
 

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -324,6 +324,12 @@ namespace XmlSchemaClassGenerator
             set { _configuration.MapUnionToWidestCommonType = value; }
         }
 
+        public bool SeparateNamespaceHierarchy
+        {
+            get { return _configuration.SeparateNamespaceHierarchy; }
+            set { _configuration.SeparateNamespaceHierarchy = value; }
+        }
+
         static Generator()
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -334,5 +334,10 @@ namespace XmlSchemaClassGenerator
         /// a numeric C# type is generated. If this is disabled, a union's type will default to string. Default is false.
         /// </summary>
         public bool MapUnionToWidestCommonType { get; set; }
+
+        /// <summary>
+        /// Separates namespace hierarchy by folder. Default is false.
+        /// </summary>
+        public bool SeparateNamespaceHierarchy { get; set; } = false;
     }
 }


### PR DESCRIPTION
Add option for separate namespace hierarchy by folder (works if `SeparateClasses` is true). Default is false.

With this option, class `PurchaseOrderType` in namespace `Generator.Prefix` places in: `Generator/Prefix/PurchaseOrderType.cs`