### PR TITLE
Allow generation of DateTimeOffset properties for xs:dateTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Options:
                                Lines starting with # and empty lines are
                                ignored.
   -o, --output=FOLDER        the FOLDER to write the resulting .cs files to
+  -d, --datetime-offset      map x:datetime to System.DateTimeOffset 
+                               instead of System.DateTime
   -i, --integer=TYPE         map xs:integer and derived types to TYPE instead
                                of automatic approximation
                                TYPE can be i[nt], l[ong], or d[ecimal]

--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -23,9 +23,9 @@ namespace XmlSchemaClassGenerator.Console
             var namespaces = new List<string>();
             var nameSubstitutes = new List<string>();
             var outputFolder = (string)null;
+            bool dateTimeWithTimeZone = false;
             Type integerType = null;
             var useIntegerTypeAsFallback = false;
-            Type dateTimeType = typeof(DateTime);
             var namespacePrefix = "";
             var verbose = false;
             var nullables = false;
@@ -85,6 +85,7 @@ Prefix with 'A:' to substitute any type/member.", v => nameSubstitutes.Add(v) },
 The line format is one mapping per line: prefixed type/member name = substitute name.
 Lines starting with # and empty lines are ignored.", v => nameSubstituteFiles.Add(v) },
                 { "o|output=", "the {FOLDER} to write the resulting .cs files to", v => outputFolder = v },
+                { "d|datetime-offset", "map xs:datetime and derived types to System.DateTimeOffset instead of System.DateTime", v => dateTimeWithTimeZone = v != null },
                 { "i|integer=", @"map xs:integer and derived types to {TYPE} instead of automatic approximation
 {TYPE} can be i[nt], l[ong], or d[ecimal]", v => {
                                          switch (v)
@@ -104,7 +105,6 @@ Lines starting with # and empty lines are ignored.", v => nameSubstituteFiles.Ad
                                          }
                                      } },
                 { "fb|fallback|use-integer-type-as-fallback", "use integer type specified via -i only if no type can be deduced", v => useIntegerTypeAsFallback = v != null },
-                { "dto|datetime-offset=", "map xs:datetime and derived types to System.DateTimeOffset instead of System.DataTime", v => dateTimeType = typeof(DateTimeOffset)},
                 { "e|edb|enable-data-binding", "enable INotifyPropertyChanged data binding", v => enableDataBinding = v != null },
                 { "r|order", "emit order for all class members stored as XML element", v => emitOrder = v != null },
                 { "c|pcl", "PCL compatible output", v => pclCompatible = v != null },
@@ -212,7 +212,7 @@ without backing field initialization for collections
                 EmitOrder = emitOrder,
                 IntegerDataType = integerType,
                 UseIntegerDataTypeAsFallback = useIntegerTypeAsFallback,
-                DateTimeDataType = dateTimeType,
+                DateTimeWithTimeZone = dateTimeWithTimeZone,
                 EntityFramework = entityFramework,
                 GenerateInterfaces = interfaces,
                 NamingScheme = pascal ? NamingScheme.PascalCase : NamingScheme.Direct,

--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -25,6 +25,7 @@ namespace XmlSchemaClassGenerator.Console
             var outputFolder = (string)null;
             Type integerType = null;
             var useIntegerTypeAsFallback = false;
+            Type dateTimeType = typeof(DateTime);
             var namespacePrefix = "";
             var verbose = false;
             var nullables = false;
@@ -103,6 +104,7 @@ Lines starting with # and empty lines are ignored.", v => nameSubstituteFiles.Ad
                                          }
                                      } },
                 { "fb|fallback|use-integer-type-as-fallback", "use integer type specified via -i only if no type can be deduced", v => useIntegerTypeAsFallback = v != null },
+                { "dto|datetime-offset=", "map xs:datetime and derived types to System.DateTimeOffset instead of System.DataTime", v => dateTimeType = typeof(DateTimeOffset)},
                 { "e|edb|enable-data-binding", "enable INotifyPropertyChanged data binding", v => enableDataBinding = v != null },
                 { "r|order", "emit order for all class members stored as XML element", v => emitOrder = v != null },
                 { "c|pcl", "PCL compatible output", v => pclCompatible = v != null },
@@ -210,6 +212,7 @@ without backing field initialization for collections
                 EmitOrder = emitOrder,
                 IntegerDataType = integerType,
                 UseIntegerDataTypeAsFallback = useIntegerTypeAsFallback,
+                DateTimeDataType = dateTimeType,
                 EntityFramework = entityFramework,
                 GenerateInterfaces = interfaces,
                 NamingScheme = pascal ? NamingScheme.PascalCase : NamingScheme.Direct,

--- a/XmlSchemaClassGenerator.Tests/DateTimeTypeTests.cs
+++ b/XmlSchemaClassGenerator.Tests/DateTimeTypeTests.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Xml.Schema;
+using Xunit;
+
+namespace XmlSchemaClassGenerator.Tests
+{
+    public sealed class DateTimeTypeTests
+    {
+        private static IEnumerable<string> ConvertXml(string xsd, Generator generatorPrototype)
+        {
+            var writer = new MemoryOutputWriter();
+
+            var gen = new Generator
+            {
+                OutputWriter = writer,
+                Version = new("Tests", "1.0.0.1"),
+                NamespaceProvider = generatorPrototype.NamespaceProvider,
+                GenerateNullables = generatorPrototype.GenerateNullables,
+                IntegerDataType = generatorPrototype.IntegerDataType,
+                UseIntegerDataTypeAsFallback = generatorPrototype.UseIntegerDataTypeAsFallback,
+                DateTimeDataType = generatorPrototype.DateTimeDataType,
+                DataAnnotationMode = generatorPrototype.DataAnnotationMode,
+                GenerateDesignerCategoryAttribute = generatorPrototype.GenerateDesignerCategoryAttribute,
+                GenerateComplexTypesForCollections = generatorPrototype.GenerateComplexTypesForCollections,
+                EntityFramework = generatorPrototype.EntityFramework,
+                AssemblyVisible = generatorPrototype.AssemblyVisible,
+                GenerateInterfaces = generatorPrototype.GenerateInterfaces,
+                MemberVisitor = generatorPrototype.MemberVisitor,
+                CodeTypeReferenceOptions = generatorPrototype.CodeTypeReferenceOptions
+            };
+
+            var set = new XmlSchemaSet();
+
+            using (var stringReader = new StringReader(xsd))
+            {
+                var schema = XmlSchema.Read(stringReader, (_, e) => throw new InvalidOperationException($"{e.Severity}: {e.Message}", e.Exception));
+                ArgumentNullException.ThrowIfNull(schema);
+                set.Add(schema);
+            }
+
+            gen.Generate(set);
+
+            return writer.Content;
+        }
+
+        [Theory]
+        [InlineData(typeof(DateTime), "System.DateTime")]
+        [InlineData(typeof(DateTimeOffset), "System.DateTimeOffset")]
+        public void TestFallbackType(Type dateTimeType, string expectedType)
+        {
+            var xsd = @$"<?xml version=""1.0"" encoding=""UTF-8""?>
+<xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
+	<xs:complexType name=""document"">
+		<xs:sequence>
+			<xs:element name=""someDate"" type=""xs:dateTime"" />
+		</xs:sequence>
+	</xs:complexType>
+</xs:schema>";
+
+            var generatedType = ConvertXml(
+                xsd, new()
+                {
+                    NamespaceProvider = new()
+                    {
+                        GenerateNamespace = _ => "Test"
+                    },
+                    DateTimeDataType = dateTimeType
+                });
+
+            var expectedProperty = $"public {expectedType} SomeDate";
+            var generatedProperty = generatedType.First();
+
+            Assert.Contains(expectedProperty, generatedProperty);
+        }
+
+    }
+}

--- a/XmlSchemaClassGenerator.Tests/DateTimeTypeTests.cs
+++ b/XmlSchemaClassGenerator.Tests/DateTimeTypeTests.cs
@@ -21,9 +21,7 @@ namespace XmlSchemaClassGenerator.Tests
                 Version = new("Tests", "1.0.0.1"),
                 NamespaceProvider = generatorPrototype.NamespaceProvider,
                 GenerateNullables = generatorPrototype.GenerateNullables,
-                IntegerDataType = generatorPrototype.IntegerDataType,
-                UseIntegerDataTypeAsFallback = generatorPrototype.UseIntegerDataTypeAsFallback,
-                DateTimeDataType = generatorPrototype.DateTimeDataType,
+                DateTimeWithTimeZone = generatorPrototype.DateTimeWithTimeZone,
                 DataAnnotationMode = generatorPrototype.DataAnnotationMode,
                 GenerateDesignerCategoryAttribute = generatorPrototype.GenerateDesignerCategoryAttribute,
                 GenerateComplexTypesForCollections = generatorPrototype.GenerateComplexTypesForCollections,
@@ -49,9 +47,9 @@ namespace XmlSchemaClassGenerator.Tests
         }
 
         [Theory]
-        [InlineData(typeof(DateTime), "System.DateTime")]
-        [InlineData(typeof(DateTimeOffset), "System.DateTimeOffset")]
-        public void TestFallbackType(Type dateTimeType, string expectedType)
+        [InlineData(false, "System.DateTime")]
+        [InlineData(true, "System.DateTimeOffset")]
+        public void TestFallbackType(bool dateTimeWithTimeZone, string expectedType)
         {
             var xsd = @$"<?xml version=""1.0"" encoding=""UTF-8""?>
 <xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
@@ -69,7 +67,7 @@ namespace XmlSchemaClassGenerator.Tests
                     {
                         GenerateNamespace = _ => "Test"
                     },
-                    DateTimeDataType = dateTimeType
+                    DateTimeWithTimeZone = dateTimeWithTimeZone
                 });
 
             var expectedProperty = $"public {expectedType} SomeDate";

--- a/XmlSchemaClassGenerator/CodeUtilities.cs
+++ b/XmlSchemaClassGenerator/CodeUtilities.cs
@@ -160,7 +160,7 @@ namespace XmlSchemaClassGenerator
                 XmlTypeCode.AnyAtomicType => configuration.MapUnionToWidestCommonType ? GetUnionType(configuration, schemaType, attribute) : typeof(string), // union
                 XmlTypeCode.AnyUri or XmlTypeCode.GDay or XmlTypeCode.GMonth or XmlTypeCode.GMonthDay or XmlTypeCode.GYear or XmlTypeCode.GYearMonth => typeof(string),
                 XmlTypeCode.Duration => configuration.NetCoreSpecificCode ? type.ValueType : typeof(string),
-                XmlTypeCode.Time => typeof(DateTime),
+                XmlTypeCode.Time or XmlTypeCode.DateTime => configuration.DateTimeDataType,
                 XmlTypeCode.Idref => typeof(string),
                 XmlTypeCode.Integer or XmlTypeCode.NegativeInteger or XmlTypeCode.NonNegativeInteger or XmlTypeCode.NonPositiveInteger or XmlTypeCode.PositiveInteger => GetIntegerDerivedType(type, configuration, restrictions),
                 XmlTypeCode.Decimal when restrictions.OfType<FractionDigitsRestrictionModel>().SingleOrDefault() is { IsSupported: true, Value: 0 } => GetIntegerDerivedType(type, configuration, restrictions),

--- a/XmlSchemaClassGenerator/CodeUtilities.cs
+++ b/XmlSchemaClassGenerator/CodeUtilities.cs
@@ -160,7 +160,7 @@ namespace XmlSchemaClassGenerator
                 XmlTypeCode.AnyAtomicType => configuration.MapUnionToWidestCommonType ? GetUnionType(configuration, schemaType, attribute) : typeof(string), // union
                 XmlTypeCode.AnyUri or XmlTypeCode.GDay or XmlTypeCode.GMonth or XmlTypeCode.GMonthDay or XmlTypeCode.GYear or XmlTypeCode.GYearMonth => typeof(string),
                 XmlTypeCode.Duration => configuration.NetCoreSpecificCode ? type.ValueType : typeof(string),
-                XmlTypeCode.Time or XmlTypeCode.DateTime => configuration.DateTimeDataType,
+                XmlTypeCode.Time or XmlTypeCode.DateTime => configuration.DateTimeWithTimeZone ? typeof(DateTimeOffset) : typeof(DateTime),
                 XmlTypeCode.Idref => typeof(string),
                 XmlTypeCode.Integer or XmlTypeCode.NegativeInteger or XmlTypeCode.NonNegativeInteger or XmlTypeCode.NonPositiveInteger or XmlTypeCode.PositiveInteger => GetIntegerDerivedType(type, configuration, restrictions),
                 XmlTypeCode.Decimal when restrictions.OfType<FractionDigitsRestrictionModel>().SingleOrDefault() is { IsSupported: true, Value: 0 } => GetIntegerDerivedType(type, configuration, restrictions),

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -175,6 +175,12 @@ namespace XmlSchemaClassGenerator
             set { _configuration.UseIntegerDataTypeAsFallback = value; }
         }
 
+        public Type DateTimeDataType
+        {
+            get { return _configuration.DateTimeDataType; }
+            set { _configuration.DateTimeDataType = value; }
+        }
+
         public bool EntityFramework
         {
             get { return _configuration.EntityFramework; }

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -175,10 +175,10 @@ namespace XmlSchemaClassGenerator
             set { _configuration.UseIntegerDataTypeAsFallback = value; }
         }
 
-        public Type DateTimeDataType
+        public bool DateTimeWithTimeZone
         {
-            get { return _configuration.DateTimeDataType; }
-            set { _configuration.DateTimeDataType = value; }
+            get { return _configuration.DateTimeWithTimeZone; }
+            set { _configuration.DateTimeWithTimeZone = value; }
         }
 
         public bool EntityFramework

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -148,6 +148,10 @@ namespace XmlSchemaClassGenerator
         /// </summary>
         public bool UseIntegerDataTypeAsFallback { get; set; }
         /// <summary>
+        /// Default date type for DateTime fields.
+        /// </summary>
+        public Type DateTimeDataType { get; set; } = typeof(DateTime);
+        /// <summary>
         /// Generate Entity Framework Code First compatible classes
         /// </summary>
         public bool EntityFramework { get; set; }

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -148,9 +148,9 @@ namespace XmlSchemaClassGenerator
         /// </summary>
         public bool UseIntegerDataTypeAsFallback { get; set; }
         /// <summary>
-        /// Default date type for DateTime fields.
+        /// Generate DateTimeOffset properties for xs:dateTime elements
         /// </summary>
-        public Type DateTimeDataType { get; set; } = typeof(DateTime);
+        public bool DateTimeWithTimeZone { get; set; } = false;
         /// <summary>
         /// Generate Entity Framework Code First compatible classes
         /// </summary>


### PR DESCRIPTION
Since the .NET XmlSerializer now also supports serializing to and from DateTimeOffset, an option has been added to use DateTimeOffset for xs:datetime properties.

Closes #171 
Relates to #458 