### PR TITLE
Do not generate DataType property in Xml serialization property

### DIFF
--- a/XmlSchemaClassGenerator/TypeModel.cs
+++ b/XmlSchemaClassGenerator/TypeModel.cs
@@ -1092,7 +1092,9 @@ namespace XmlSchemaClassGenerator
                     while (xmlSchemaType != null)
                     {
                         var qualifiedName = xmlSchemaType.GetQualifiedName();
-                        if (qualifiedName.Namespace == XmlSchema.Namespace && qualifiedName.Name != "anySimpleType")
+
+                        if ((qualifiedName.Namespace == XmlSchema.Namespace && qualifiedName.Name != "anySimpleType") &&
+                            (xmlSchemaType.Datatype.ValueType == typeof(DateTime) && configuration.DateTimeWithTimeZone) == false)
                         {
                             args.Add(new("DataType", new CodePrimitiveExpression(qualifiedName.Name)));
                             break;


### PR DESCRIPTION
When generating a C# class for an XSD that has datetime properties, and the option to generate `DateTimeOffset` properties for those datetime elements, do not specify the `DataType` attribute on the XmlElementAttribute

Fixes #465 