### PR TITLE
Fix `namingscheme` parameter

### DIFF
--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -163,7 +163,7 @@ with or without backing field initialization for collections
                 { "uc|unionCommonType", "generate a common type for unions if possible (default is false)", v => unionCommonType = v != null },
                 { "ec|serializeEmptyCollections", "serialize empty collections (default is false)", v => serializeEmptyCollections = v != null },
                 { "dtd|allowDtdParse", "allows dtd parse (default is false)", v => allowDtdParse = v != null },
-                { "ns|namingScheme", @"use the specified naming scheme for class and property names (default is Pascal; can be: Direct, Pascal, Legacy)",
+                { "ns|namingScheme=", @"use the specified naming scheme for class and property names (default is Pascal; can be: Direct, Pascal, Legacy)",
                     v =>
                     {
                         namingScheme = v?.ToLowerInvariant() switch


### PR DESCRIPTION
The value of the namingscheme parameter was ignored, because the parser did not expect a value after `--namingScheme`.