### PR TITLE
Allow disabling of merging restrictions with base in configuration

### DIFF
--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -61,6 +61,7 @@ namespace XmlSchemaClassGenerator.Console
             var generateCommandLineArgs = true;
             var useArrayItemAttribute = true;
             var enumAsString = false;
+            var disableMergeRestrictionsWithBase = false;
             var namespaceFiles = new List<string>();
             var nameSubstituteFiles = new List<string>();
             var unionCommonType = false;
@@ -159,6 +160,7 @@ with or without backing field initialization for collections
                 { "nr|nullableReferenceAttributes", "generate attributes for nullable reference types (default is false)", v => nullableReferenceAttributes = v != null },
                 { "ar|useArrayItemAttribute", "use ArrayItemAttribute for sequences with single elements (default is true)", v => useArrayItemAttribute = v != null },
                 { "es|enumAsString", "Use string instead of enum for enumeration", v => enumAsString = v != null },
+                { "dmb|disableMergeRestrictionsWithBase", "Disable merging of simple type restrictions with base type restrictions", v => disableMergeRestrictionsWithBase = v != null },
                 { "ca|commandArgs", "generate a comment with the exact command line arguments that were used to generate the source code (default is true)", v => generateCommandLineArgs = v != null },
                 { "uc|unionCommonType", "generate a common type for unions if possible (default is false)", v => unionCommonType = v != null },
                 { "ec|serializeEmptyCollections", "serialize empty collections (default is false)", v => serializeEmptyCollections = v != null },
@@ -259,6 +261,7 @@ with or without backing field initialization for collections
                 GenerateCommandLineArgumentsComment = generateCommandLineArgs,
                 UseArrayItemAttribute = useArrayItemAttribute,
                 EnumAsString = enumAsString,
+                MergeRestrictionsWithBase = !disableMergeRestrictionsWithBase,
                 MapUnionToWidestCommonType = unionCommonType,
                 SeparateNamespaceHierarchy = separateNamespaceHierarchy,
                 SerializeEmptyCollections = serializeEmptyCollections,

--- a/XmlSchemaClassGenerator/Generator.cs
+++ b/XmlSchemaClassGenerator/Generator.cs
@@ -39,6 +39,12 @@ namespace XmlSchemaClassGenerator
             set { _configuration.EnumAsString = value; }
         }
 
+        public bool MergeRestrictionsWithBase
+        {
+            get { return _configuration.MergeRestrictionsWithBase; }
+            set { _configuration.MergeRestrictionsWithBase = value; }
+        }
+
         public bool GenerateComplexTypesForCollections
         {
             get { return _configuration.GenerateComplexTypesForCollections; }

--- a/XmlSchemaClassGenerator/GeneratorConfiguration.cs
+++ b/XmlSchemaClassGenerator/GeneratorConfiguration.cs
@@ -39,9 +39,12 @@ namespace XmlSchemaClassGenerator
             Version = VersionProvider.CreateFromAssembly();
             EnableUpaCheck = true;
             CommandLineArgumentsProvider = CommandLineArgumentsProvider.CreateFromEnvironment();
+            MergeRestrictionsWithBase = true;
         }
 
         public bool EnumAsString { get; set; }
+
+        public bool MergeRestrictionsWithBase { get; set; }
 
         /// <summary>
         /// The writer to be used to generate the code files

--- a/XmlSchemaClassGenerator/ModelBuilder.cs
+++ b/XmlSchemaClassGenerator/ModelBuilder.cs
@@ -635,6 +635,7 @@ namespace XmlSchemaClassGenerator
 
                 var facets = simpleType.Content switch
                 {
+                    XmlSchemaSimpleTypeRestriction typeRestriction when !_configuration.MergeRestrictionsWithBase => typeRestriction.Facets.Cast<XmlSchemaFacet>().ToList(),
                     XmlSchemaSimpleTypeUnion typeUnion when AllMembersHaveFacets(typeUnion, out baseFacets) => baseFacets.SelectMany(f => f).ToList(),
                     _ => MergeRestrictions(simpleType)
                 };


### PR DESCRIPTION
`v2.1.954` has been a breaking change due to the merging of restrictions in 4539c1e3e4443d977023bc85858608d81f2db12c.

As a result, properties with numeric restrictions were previously generated as string and now generated as numeric types (byte/ushort/uint/int/long/etc.). This configuration allows projects to update to the latest version gradually with the ability to opt-out from the new behaviour temporarily.

With the configuration, projects using the package can update to the latest version in 2 parts, one with only changes to comments and attributes, and after that with only changes in the generated property types.