### PR TITLE
Fix "namingScheme" argument is ignored when "typeNameSubstitute" argument is provided in console

### DIFF
--- a/XmlSchemaClassGenerator.Console/Program.cs
+++ b/XmlSchemaClassGenerator.Console/Program.cs
@@ -279,7 +279,7 @@ with or without backing field initialization for collections
 
             if (nameSubstituteMap.Any())
             {
-                generator.NamingProvider = new SubstituteNamingProvider(nameSubstituteMap);
+                generator.NamingProvider = new SubstituteNamingProvider(generator.NamingScheme, nameSubstituteMap);
             }
 
             generator.CommentLanguages.UnionWith(commentLanguages);


### PR DESCRIPTION
When --namingScheme argument and --typeNameSubstitute aregument are provided at the same time, the --namingScheme is ignored and always uses PascalCase.
`--typeNameSubstitute=T:OriginalName=NewName--namingScheme=Direct`

Closes #532