### PR TITLE
Don't emit DataType for DateOnly and TimeOny types

### DIFF
--- a/XmlSchemaClassGenerator.Tests/DateOnlyTimeOnlyTests.cs
+++ b/XmlSchemaClassGenerator.Tests/DateOnlyTimeOnlyTests.cs
@@ -72,8 +72,8 @@ public sealed class DateOnlyTimeOnlyTests
 
         Assert.Contains("public System.DateOnly SomeDate", code);
         Assert.Contains("public System.TimeOnly SomeTime", code);
-        Assert.Contains("DataType=\"date\"", code);
-        Assert.Contains("DataType=\"time\"", code);
+        Assert.DoesNotContain("DataType=\"date\"", code);
+        Assert.DoesNotContain("DataType=\"time\"", code);
     }
 
     [Fact]
@@ -191,7 +191,7 @@ public sealed class DateOnlyTimeOnlyTests
         Assert.DoesNotContain("DataType=\"date\"", code);
     }
     [Fact]
-    public void WhenUseDateOnlyIsTrue_AndDateTimeWithTimeZoneIsTrue_DateOnlyAndTimeOnlyAreGenerated_WithDataTypeAttribute()
+    public void WhenUseDateOnlyIsTrue_AndDateTimeWithTimeZoneIsTrue_DateOnlyAndTimeOnlyAreGenerated()
     {
         var xsd = @$"<?xml version=""1.0"" encoding=""UTF-8""?>
 <xs:schema elementFormDefault=""qualified"" xmlns:xs=""http://www.w3.org/2001/XMLSchema"">
@@ -218,7 +218,7 @@ public sealed class DateOnlyTimeOnlyTests
 
         Assert.Contains("public System.DateOnly SomeDate", code);
         Assert.Contains("public System.TimeOnly SomeTime", code);
-        Assert.Contains("DataType=\"date\"", code);
-        Assert.Contains("DataType=\"time\"", code);
+        Assert.DoesNotContain("DataType=\"date\"", code);
+        Assert.DoesNotContain("DataType=\"time\"", code);
     }
 }

--- a/XmlSchemaClassGenerator/CodeUtilities.cs
+++ b/XmlSchemaClassGenerator/CodeUtilities.cs
@@ -78,7 +78,7 @@ namespace XmlSchemaClassGenerator
         public static bool? IsDataTypeAttributeAllowed(this XmlSchemaDatatype type, GeneratorConfiguration configuration) => type.TypeCode switch
         {
             XmlTypeCode.AnyAtomicType => false,// union
-            XmlTypeCode.Date or XmlTypeCode.Time when configuration.UseDateOnly => true,
+            XmlTypeCode.Date or XmlTypeCode.Time when configuration.UseDateOnly => false,
             XmlTypeCode.DateTime or XmlTypeCode.Date or XmlTypeCode.Time => !configuration.DateTimeWithTimeZone,
             XmlTypeCode.Base64Binary or XmlTypeCode.HexBinary => true,
             _ => false,


### PR DESCRIPTION
This is related to my previous pull request https://github.com/mganss/XmlSchemaClassGenerator/pull/573, after testing I've figured out that `DateType` attribute fails for new types, for example:

```cs
using System.Xml.Serialization;

// DTO with DateTime field
public class PersonDto
{
    public int Id { get; set; }
    public string Name { get; set; } = string.Empty;
    [XmlElement("BirthDate", DataType="date")]
    public DateOnly BirthDate { get; set; }
}

class Program
{
    static void Main()
    {
        // Create a sample DTO
        var person = new PersonDto
        {
            Id = 1,
            Name = "John Doe",
            BirthDate = new DateOnly(1990, 5, 15)
        };

        // Serialize to XML
        var serializer = new XmlSerializer(typeof(PersonDto));

        using var stringWriter = new StringWriter();
        serializer.Serialize(stringWriter, person);
        string xml = stringWriter.ToString();

        Console.WriteLine("Serialized XML:");
        Console.WriteLine(xml);
        Console.WriteLine();

        // Deserialize back from XML
        using var stringReader = new StringReader(xml);
        var deserializedPerson = (PersonDto?)serializer.Deserialize(stringReader);

        if (deserializedPerson != null)
        {
            Console.WriteLine("Deserialized DTO:");
            Console.WriteLine($"Id: {deserializedPerson.Id}");
            Console.WriteLine($"Name: {deserializedPerson.Name}");
            Console.WriteLine($"BirthDate: {deserializedPerson.BirthDate:yyyy-MM-dd}");
        }
    }
}
```
This code fails with error `Value 'date' cannot be used for the XmlElementAttribute.DataType property. The datatype 'http://www.w3.org/2001/XMLSchema:date' is missing` 
In this PR I've disallowed DataType for DateOnly and TimeOnly types.