### PR TITLE
Fix: use generic Enum.TryParse<> for EnumValue property (net48 / netstandard2.x compat)

### DIFF
--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -278,6 +278,51 @@ public class XmlTests(ITestOutputHelper output)
         Assert.Null(stringValue);
     }
 
+     /// <summary>
+    /// Verifies that the EnumValue property is generated with the generic Enum.TryParse<> form,
+    /// which is compatible with net48/netstandard2.0.
+    /// The non-generic overload Enum.TryParse(Type, string, bool, out object) is .NET 5+ only.
+    /// Regression guard: generator must never emit the typeof(T) form.
+    /// </summary>
+    [Fact, TestPriority(1)]
+    [UseCulture("en-US")]
+    public void TestSimpleContentEnum_EnumValueUsesGenericTryParse()
+    {
+        var writer = new MemoryOutputWriter();
+        var gen = new Generator { OutputWriter = writer };
+        gen.Generate(["xsd/simple/simplecontent-enum.xsd"]);
+
+        const string expectedEnumValueProperty = @"
+        [System.Xml.Serialization.XmlIgnoreAttribute()]
+        public virtual System.Nullable<TransConfirmationCodeTypeEnum> EnumValue
+        {
+            get
+            {
+                TransConfirmationCodeTypeEnum result;
+                if (System.Enum.TryParse<TransConfirmationCodeTypeEnum>(this.Value, true, out result))
+                {
+                    return result;
+                }
+                return null;
+            }
+            set
+            {
+                if ((value != null))
+                {
+                    this.Value = value.ToString();
+                }
+                else
+                {
+                    this.Value = null;
+                }
+            }
+        }
+    }";
+
+        Assert.Contains(expectedEnumValueProperty, writer.Content.First());
+    }
+
+
     [Fact, TestPriority(1)]
     [UseCulture("en-US")]
     public void TestList()

--- a/XmlSchemaClassGenerator.Tests/XmlTests.cs
+++ b/XmlSchemaClassGenerator.Tests/XmlTests.cs
@@ -316,8 +316,7 @@ public class XmlTests(ITestOutputHelper output)
                     this.Value = null;
                 }
             }
-        }
-    }";
+        }";
 
         Assert.Contains(expectedEnumValueProperty, writer.Content.First());
     }

--- a/XmlSchemaClassGenerator/Models/ClassModel.cs
+++ b/XmlSchemaClassGenerator/Models/ClassModel.cs
@@ -123,28 +123,35 @@ public class ClassModel(GeneratorConfiguration configuration) : ReferenceTypeMod
                     enumValueProperty.CustomAttributes.Add(ignoreAttribute);
 
                     // Getter: Try to parse the Value property to enum
-                    // if (Enum.TryParse(typeof(EnumType), Value, true, out var result))
-                    //     return (EnumType)result;
+                    // if (System.Enum.TryParse<EnumType>(this.Value, true, out result))
+                    //     return result;
                     // return null;
-                    var resultVariable = new CodeVariableDeclarationStatement(typeof(object), "result");
-                    var tryParseCondition = new CodeMethodInvokeExpression(
+                    //
+                    // CodeMethodReferenceExpression accepts type parameters, which causes the C# code
+                    // provider to emit the generic Enum.TryParse<T> form. This is available since
+                    // .NET 4.0 and works on all target frameworks, unlike the non-generic overload
+                    // Enum.TryParse(Type, string, bool, out object) which only exists from .NET 5+.
+                    var resultVariable = new CodeVariableDeclarationStatement(enumTypeReference, "result");
+
+                    var tryParseMethodRef = new CodeMethodReferenceExpression(
                         new CodeTypeReferenceExpression(typeof(Enum)),
                         "TryParse",
-                        new CodeTypeOfExpression(enumTypeReference),
+                        enumTypeReference);
+
+                    var tryParseCondition = new CodeMethodInvokeExpression(
+                        tryParseMethodRef,
                         new CodePropertyReferenceExpression(
                             new CodeThisReferenceExpression(),
                             textName),
                         new CodePrimitiveExpression(true),
                         new CodeDirectionExpression(FieldDirection.Out, new CodeVariableReferenceExpression("result")));
 
-                    var returnCastResult = new CodeMethodReturnStatement(
-                        new CodeCastExpression(
-                            nullableEnumTypeReference,
-                            new CodeVariableReferenceExpression("result")));
+                    var returnResult = new CodeMethodReturnStatement(
+                        new CodeVariableReferenceExpression("result"));
 
                     var ifTryParse = new CodeConditionStatement(
                         tryParseCondition,
-                        returnCastResult);
+                        returnResult);
 
                     enumValueProperty.GetStatements.Add(resultVariable);
                     enumValueProperty.GetStatements.Add(ifTryParse);


### PR DESCRIPTION
## Summary

When generating an `EnumValue` adapter property for a derived class with a `simpleContent` restriction that carries enum facets, the generated getter calls the **non-generic** `System.Enum.TryParse(Type, string, bool, out object)` overload. This overload was introduced in **.NET 5** and does not exist in .NET Framework 4.x or .NET Standard 2.x, causing a compile error in those targets.

## Steps to reproduce

1. Define an XSD with a `simpleContent` restriction + enum facets, e.g.:

```xml
<xs:complexType name="CodeType">
  <xs:simpleContent>
    <xs:extension base="xs:string">
      <xs:attribute name="listID" type="xs:string"/>
    </xs:extension>
  </xs:simpleContent>
</xs:complexType>

<xs:complexType name="TransConfirmationCodeType">
  <xs:simpleContent>
    <xs:restriction base="CodeType">
      <xs:enumeration value="Always"/>
      <xs:enumeration value="Never"/>
      <xs:enumeration value="OnError"/>
    </xs:restriction>
  </xs:simpleContent>
</xs:complexType>
```

2. Generate C# classes with `xscgen`.
3. Compile the generated code targeting `net48` or `netstandard2.0`.

## Actual behaviour

Compilation fails with:

```
error CS1501: No overload for method 'TryParse' takes 4 arguments
```

The generated getter contains:

```csharp
object result;
if (System.Enum.TryParse(typeof(TransConfirmationCodeTypeEnum), this.Value, true, out result))
{
    return ((System.Nullable<TransConfirmationCodeTypeEnum>)(result));
}
return null;
```

`System.Enum.TryParse(Type, string, bool, out object)` does **not exist** in:

- .NET Framework 4.x (including 4.8)
- .NET Standard 2.0 / 2.1

It was introduced in **.NET 5** only.

## Root cause

In `ClassModel.cs`, the `EnumValue` getter is built using `CodeMethodInvokeExpression` with `new CodeTypeOfExpression(…)` as the first argument. The C# CodeDOM provider maps this directly to the non-generic `TryParse(typeof(T), …)` call.

## Fix

Use the **generic** `Enum.TryParse<TEnum>` overload, which has been available since **.NET 4.0**. `CodeMethodReferenceExpression` accepts type parameters via its third constructor argument, which causes the C# CodeDOM provider to emit the generic form — no `CodeSnippetExpression` needed:

```csharp
var tryParseMethodRef = new CodeMethodReferenceExpression(
    new CodeTypeReferenceExpression(typeof(Enum)),
    "TryParse",
    enumTypeReference);  // type parameter → emits TryParse<EnumType>
```

Key changes:
- `CodeMethodReferenceExpression` with `enumTypeReference` as type argument replaces `CodeTypeOfExpression` — emits `TryParse<T>` instead of `TryParse(typeof(T), ...)`.
- `result` is declared as `EnumType` (not `object`), so no cast is needed on return.

## Compatibility

| Target framework   | Before      | After |
|--------------------|-------------|-------|
| .NET Framework 4.x | ❌ `CS1501` | ✅    |
| .NET Standard 2.x  | ❌ `CS1501` | ✅    |
| .NET 5+            | ✅           | ✅    |
| .NET 8+            | ✅           | ✅    |

## Tests

A regression test `TestSimpleContentEnum_EnumValueUsesGenericTryParse` is included that asserts the full generated `EnumValue` property body, ensuring the generic `TryParse<T>` form is emitted and the `typeof(T)` form is never produced.

---

Happy to adjust if you have an alternative suggestion or preference for how this should be handled.