### PR TITLE
Reference backing fields called "value" using "this.value"

### DIFF
--- a/XmlSchemaClassGenerator.Tests/BackingFieldNamingTests.cs
+++ b/XmlSchemaClassGenerator.Tests/BackingFieldNamingTests.cs
@@ -1,0 +1,88 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Xml.Schema;
+using Xunit;
+
+namespace XmlSchemaClassGenerator.Tests;
+
+public sealed class BackingFieldNamingTests
+{
+    const string TypeWithValueCollectionXsd = """
+            <?xml version="1.0"?>
+            <xsd:schema xmlns="http://www.example.org/Values" targetNamespace="http://www.example.org/Values" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
+                <xsd:complexType name="TypeWithValueCollection">
+                    <xsd:sequence>
+                        <xsd:element name="Value" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
+                    </xsd:sequence>
+                </xsd:complexType>
+            </xsd:schema>
+            """;
+
+    private static string GenerateCode(string xsd, Generator generatorPrototype)
+    {
+        var writer = new MemoryOutputWriter();
+
+        var gen = new Generator
+        {
+            OutputWriter = writer,
+            Version = new("Tests", "1.0.0.1"),
+            NamespaceProvider = generatorPrototype.NamespaceProvider,
+            EnableDataBinding = generatorPrototype.EnableDataBinding,
+            PrivateMemberPrefix = generatorPrototype.PrivateMemberPrefix,
+            CollectionSettersMode = generatorPrototype.CollectionSettersMode,
+        };
+
+        var set = new XmlSchemaSet();
+
+        using (var stringReader = new StringReader(xsd))
+        {
+            var schema = XmlSchema.Read(stringReader, (_, e) => throw new InvalidOperationException($"{e.Severity}: {e.Message}", e.Exception));
+            ArgumentNullException.ThrowIfNull(schema);
+            set.Add(schema);
+        }
+
+        gen.Generate(set);
+
+        return writer.Content.First();
+    }
+
+    [Fact]
+    public void BackingFieldNamedValue_WithEmptyPrefix_GeneratesValidCode()
+    {
+        var generatedCode = GenerateCode(TypeWithValueCollectionXsd, new Generator
+        {
+            NamespaceProvider = new NamespaceProvider
+            {
+                GenerateNamespace = _ => "Test"
+            },
+            EnableDataBinding = true,
+            PrivateMemberPrefix = "",
+            CollectionSettersMode = CollectionSettersMode.Private,
+        });
+
+        Assert.Contains("return this.value;", generatedCode);
+        Assert.Contains("this.value = value;", generatedCode);
+
+        Compiler.Compile(nameof(BackingFieldNamedValue_WithEmptyPrefix_GeneratesValidCode), generatedCode);
+    }
+
+    [Fact]
+    public void BackingFieldNamedValue_WithDefaultPrefix_GeneratesValidCode()
+    {
+        var generatedCode = GenerateCode(TypeWithValueCollectionXsd, new Generator
+        {
+            NamespaceProvider = new NamespaceProvider
+            {
+                GenerateNamespace = _ => "Test"
+            },
+            EnableDataBinding = true,
+            PrivateMemberPrefix = "_",
+            CollectionSettersMode = CollectionSettersMode.Private,
+        });
+
+        Assert.Contains("return _value;", generatedCode);
+        Assert.Contains("_value = value;", generatedCode);
+        Compiler.Compile(nameof(BackingFieldNamedValue_WithDefaultPrefix_GeneratesValidCode), generatedCode);
+    }
+}

--- a/XmlSchemaClassGenerator/Models/PropertyModel.cs
+++ b/XmlSchemaClassGenerator/Models/PropertyModel.cs
@@ -82,7 +82,7 @@ public class PropertyModel(GeneratorConfiguration configuration, string name, Ty
         {{
             get
             {{
-                return {backingField.Name};
+                return {backingFieldReference()};
             }}
             {setter}
             {{{(typeCode, withDataBinding) switch
@@ -90,16 +90,16 @@ public class PropertyModel(GeneratorConfiguration configuration, string name, Ty
             (PropertyValueTypeCode.ValueType, true) => $@"
                 if ({checkEquality()}){assignAndNotify()}",
             (PropertyValueTypeCode.Other or PropertyValueTypeCode.Array, true) => $@"
-                if ({backingField.Name} == value)
+                if ({backingFieldReference()} == value)
                     return;
-                if ({backingField.Name} == null || value == null || {checkEquality()}){assignAndNotify()}",
+                if ({backingFieldReference()} == null || value == null || {checkEquality()}){assignAndNotify()}",
             _ => assign(),
         }}
             }}
         }}");
 
         string assign() => $@"
-                {backingField.Name} = value;";
+                {backingFieldReference()} = value;";
 
         string assignAndNotify() => $@"
                 {{{assign()}
@@ -107,7 +107,9 @@ public class PropertyModel(GeneratorConfiguration configuration, string name, Ty
                 }}";
 
         string checkEquality()
-            => $"!{backingField.Name}.{(typeCode is PropertyValueTypeCode.Array ? nameof(Enumerable.SequenceEqual) : EqualsMethod)}(value)";
+            => $"!{backingFieldReference()}.{(typeCode is PropertyValueTypeCode.Array ? nameof(Enumerable.SequenceEqual) : EqualsMethod)}(value)";
+
+        string backingFieldReference() => backingField.Name == "value" ? "this.value" : backingField.Name;
     }
 
     private ClassModel TypeClassModel => Type as ClassModel;


### PR DESCRIPTION
Fix incorrect setters generated for collections of elements called "Value" when the no private member prefix is used.

The issue occurs for XSDs such as listed below, when the tool is executed with the `--noUnderscore` option.

```xsd
<?xml version="1.0"?>
<xsd:schema xmlns="http://www.example.org/Values" targetNamespace="http://www.example.org/Values" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
    <xsd:complexType name="TypeWithValueCollection">
        <xsd:sequence>
            <xsd:element name="Value" type="xsd:string" minOccurs="0" maxOccurs="unbounded" />
        </xsd:sequence>
    </xsd:complexType>
</xsd:schema>
```

Code generated before the fix, with a setter that does not change the backing field:

```csharp
[System.Xml.Serialization.XmlIgnoreAttribute()]
private System.Collections.ObjectModel.Collection<string> value;

[System.Xml.Serialization.XmlElementAttribute("Value")]
public System.Collections.ObjectModel.Collection<string> Value
{
    get
    {
        return value;
    }
    set
    {
        value = value;
    }
}
```

Code generated after the fix:

```csharp
[System.Xml.Serialization.XmlIgnoreAttribute()]
private System.Collections.ObjectModel.Collection<string> value;

[System.Xml.Serialization.XmlElementAttribute("Value")]
public System.Collections.ObjectModel.Collection<string> Value
{
    get
    {
        return this.value;
    }
    set
    {
        this.value = value;
    }
}
```